### PR TITLE
Move navigation controls to title bar

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -889,11 +889,10 @@ const App: React.FC = () => {
     <IconContext.Provider value={settings.iconSet}>
       <TooltipProvider>
         <div className="flex flex-col h-screen">
-          <TitleBar />
-          <MenuBar 
-            onNewRepo={() => handleOpenRepoForm('new')} 
-            activeView={activeView} 
-            onSetView={setActiveView}
+          <TitleBar activeView={activeView} onSetView={setActiveView} />
+          <MenuBar
+            onNewRepo={() => handleOpenRepoForm('new')}
+            activeView={activeView}
             onCheckAllForUpdates={handleCheckAllForUpdates}
             isCheckingAll={isCheckingAll}
             onToggleAllCategories={toggleAllCategoriesCollapse}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,18 +1,93 @@
 import React from 'react';
 import WindowControls from './titlebar/WindowControls';
 import { GitBranchIcon } from './icons/GitBranchIcon';
+import { HomeIcon } from './icons/HomeIcon';
+import { CogIcon } from './icons/CogIcon';
+import { InformationCircleIcon } from './icons/InformationCircleIcon';
+import { SunIcon } from './icons/SunIcon';
+import { MoonIcon } from './icons/MoonIcon';
+import { useSettings } from '../contexts/SettingsContext';
+import type { AppView } from '../types';
+import { useTooltip } from '../hooks/useTooltip';
 
-const TitleBar: React.FC = () => {
+interface TitleBarProps {
+  activeView: AppView;
+  onSetView: (view: AppView) => void;
+}
+
+const TitleBar: React.FC<TitleBarProps> = ({ activeView, onSetView }) => {
+  const { settings, saveSettings } = useSettings();
+  const isEditing = activeView === 'edit-repository';
+
+  const handleToggleTheme = () => {
+    const newTheme = settings.theme === 'dark' ? 'light' : 'dark';
+    saveSettings({ ...settings, theme: newTheme });
+  };
+
+  const navButtonStyle = "p-1.5 rounded-md text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-300/70 dark:hover:bg-gray-700/70 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-200 dark:focus:ring-offset-gray-700 focus:ring-blue-500 transition-colors";
+  const disabledNavButtonStyle = "p-1.5 rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed";
+  const activeDashboardStyle = "p-1.5 rounded-md bg-red-600 dark:bg-red-700 text-white";
+  const activeSettingsStyle = "p-1.5 rounded-md bg-green-600 dark:bg-green-700 text-white";
+  const activeInfoStyle = "p-1.5 rounded-md bg-blue-600 dark:bg-blue-700 text-white";
+
+  const dashboardTooltip = useTooltip('Dashboard');
+  const settingsTooltip = useTooltip('Settings');
+  const infoTooltip = useTooltip('Information');
+  const themeTooltip = useTooltip(`Switch to ${settings.theme === 'dark' ? 'light' : 'dark'} mode`);
+
   return (
-    <header 
+    <header
       style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
-      className="bg-gray-200 dark:bg-gray-800/90 h-[var(--title-bar-height)] flex items-center justify-between pl-2 flex-shrink-0"
+      className="bg-gray-200 dark:bg-gray-800/90 h-[var(--title-bar-height)] flex items-center justify-between pl-2 pr-0 flex-shrink-0"
     >
-      <div className="flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-300" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
-          <GitBranchIcon className="h-5 w-5 text-blue-600 dark:text-blue-500" />
-          <span>Git Automation Dashboard</span>
+      <div
+        className="flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-300"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      >
+        <GitBranchIcon className="h-5 w-5 text-blue-600 dark:text-blue-500" />
+        <span>Git Automation Dashboard</span>
       </div>
-      <WindowControls />
+      <div className="flex items-center" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
+        <div className="flex items-center gap-1 pr-1 border-r border-gray-300/60 dark:border-gray-700/60 mr-1">
+          <button
+            {...dashboardTooltip}
+            onClick={() => onSetView('dashboard')}
+            disabled={isEditing}
+            className={isEditing ? disabledNavButtonStyle : (activeView === 'dashboard' ? activeDashboardStyle : navButtonStyle)}
+            aria-label="Dashboard"
+          >
+            <HomeIcon className="h-5 w-5" />
+          </button>
+          <button
+            {...settingsTooltip}
+            onClick={() => onSetView('settings')}
+            disabled={isEditing}
+            className={isEditing ? disabledNavButtonStyle : (activeView === 'settings' ? activeSettingsStyle : navButtonStyle)}
+            aria-label="Settings"
+          >
+            <CogIcon className="h-5 w-5" />
+          </button>
+          <button
+            {...infoTooltip}
+            onClick={() => onSetView('info')}
+            disabled={isEditing}
+            className={isEditing ? disabledNavButtonStyle : (activeView === 'info' ? activeInfoStyle : navButtonStyle)}
+            aria-label="Information"
+          >
+            <InformationCircleIcon className="h-5 w-5" />
+          </button>
+          <button
+            {...themeTooltip}
+            onClick={handleToggleTheme}
+            disabled={isEditing}
+            className={isEditing ? disabledNavButtonStyle : navButtonStyle}
+            aria-label="Toggle theme"
+          >
+            {settings.theme === 'dark' ? <SunIcon className="h-5 w-5" /> : <MoonIcon className="h-5 w-5" />}
+          </button>
+        </div>
+        <WindowControls />
+      </div>
     </header>
   );
 };

--- a/components/MenuBar.tsx
+++ b/components/MenuBar.tsx
@@ -1,51 +1,25 @@
 import React from 'react';
 import type { AppView } from '../types';
 import { PlusIcon } from './icons/PlusIcon';
-import { CogIcon } from './icons/CogIcon';
-import { InformationCircleIcon } from './icons/InformationCircleIcon';
-import { HomeIcon } from './icons/HomeIcon';
 import { useTooltip } from '../hooks/useTooltip';
 import { CloudArrowDownIcon } from './icons/CloudArrowDownIcon';
 import { ArrowsPointingInIcon } from './icons/ArrowsPointingInIcon';
 import { ArrowsPointingOutIcon } from './icons/ArrowsPointingOutIcon';
-import { useSettings } from '../contexts/SettingsContext';
-import { SunIcon } from './icons/SunIcon';
-import { MoonIcon } from './icons/MoonIcon';
 
 interface MenuBarProps {
   onNewRepo: () => void;
   activeView: AppView;
-  onSetView: (view: AppView) => void;
   onCheckAllForUpdates: () => void;
   isCheckingAll: boolean;
   onToggleAllCategories: () => void;
   canCollapseAll: boolean;
 }
 
-const MenuBar: React.FC<MenuBarProps> = ({ onNewRepo, activeView, onSetView, onCheckAllForUpdates, isCheckingAll, onToggleAllCategories, canCollapseAll }) => {
-  const { settings, saveSettings } = useSettings();
-
-  const handleToggleTheme = () => {
-    const newTheme = settings.theme === 'dark' ? 'light' : 'dark';
-    saveSettings({ ...settings, theme: newTheme });
-  };
-
-  const navButtonStyle = "p-2 rounded-md text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-300 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 dark:focus:ring-offset-gray-800 focus:ring-blue-500 transition-colors";
-  
-  const activeDashboardStyle = "p-2 rounded-md bg-red-600 dark:bg-red-700 text-white";
-  const activeSettingsStyle = "p-2 rounded-md bg-green-600 dark:bg-green-700 text-white";
-  const activeInfoStyle = "p-2 rounded-md bg-blue-600 dark:bg-blue-700 text-white";
-  
-  const disabledNavButtonStyle = "p-2 rounded-md text-gray-400 dark:text-gray-600 cursor-not-allowed";
-
+const MenuBar: React.FC<MenuBarProps> = ({ onNewRepo, activeView, onCheckAllForUpdates, isCheckingAll, onToggleAllCategories, canCollapseAll }) => {
   const isEditing = activeView === 'edit-repository';
-  
-  const dashboardTooltip = useTooltip('Dashboard');
-  const settingsTooltip = useTooltip('Settings');
-  const infoTooltip = useTooltip('Information');
+
   const checkUpdatesTooltip = useTooltip('Check all repositories for updates');
   const expandCollapseTooltip = useTooltip(canCollapseAll ? 'Collapse all categories' : 'Expand all categories');
-  const themeTooltip = useTooltip(`Switch to ${settings.theme === 'dark' ? 'light' : 'dark'} mode`);
 
   return (
     <div className="bg-gray-100 dark:bg-gray-900/80 backdrop-blur-sm shadow-sm flex-shrink-0 z-20">
@@ -71,7 +45,7 @@ const MenuBar: React.FC<MenuBarProps> = ({ onNewRepo, activeView, onSetView, onC
                   <CloudArrowDownIcon className={`h-5 w-5 mr-0 sm:mr-2 ${isCheckingAll ? 'animate-pulse' : ''}`} />
                   <span className="hidden sm:inline">{isCheckingAll ? 'Checking...' : 'Check Updates'}</span>
                 </button>
-                 <button
+                <button
                   {...expandCollapseTooltip}
                   onClick={onToggleAllCategories}
                   disabled={isEditing}
@@ -82,44 +56,6 @@ const MenuBar: React.FC<MenuBarProps> = ({ onNewRepo, activeView, onSetView, onC
                 </button>
               </>
             )}
-          </div>
-          <div className="flex items-center space-x-1 sm:space-x-2">
-            <button
-              {...dashboardTooltip}
-              onClick={() => onSetView('dashboard')}
-              disabled={isEditing}
-              className={isEditing ? disabledNavButtonStyle : (activeView === 'dashboard' ? activeDashboardStyle : navButtonStyle)}
-              aria-label="Dashboard"
-            >
-              <HomeIcon className="h-6 w-6" />
-            </button>
-            <button
-              {...settingsTooltip}
-              onClick={() => onSetView('settings')}
-              disabled={isEditing}
-              className={isEditing ? disabledNavButtonStyle : (activeView === 'settings' ? activeSettingsStyle : navButtonStyle)}
-              aria-label="Settings"
-            >
-              <CogIcon className="h-6 w-6" />
-            </button>
-            <button
-              {...infoTooltip}
-              onClick={() => onSetView('info')}
-              disabled={isEditing}
-              className={isEditing ? disabledNavButtonStyle : (activeView === 'info' ? activeInfoStyle : navButtonStyle)}
-              aria-label="Information"
-            >
-              <InformationCircleIcon className="h-6 w-6" />
-            </button>
-            <button
-              {...themeTooltip}
-              onClick={handleToggleTheme}
-              disabled={isEditing}
-              className={isEditing ? disabledNavButtonStyle : navButtonStyle}
-              aria-label="Toggle theme"
-            >
-              {settings.theme === 'dark' ? <SunIcon className="h-6 w-6" /> : <MoonIcon className="h-6 w-6" />}
-            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- move the dashboard, settings, information, and theme controls into the title bar alongside the window controls
- simplify the menu bar so it focuses on repository actions
- connect the title bar to application view state to keep navigation and theme toggling working

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6b9e715483329d588ca595c98794