### PR TITLE
Move dashboard action buttons into the title bar

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,7 +4,6 @@ import { useRepositoryManager } from './hooks/useRepositoryManager';
 import type { Repository, GlobalSettings, AppView, Task, LogEntry, LocalPathState, Launchable, LaunchConfig, DetailedStatus, BranchInfo, UpdateStatusMessage, ToastMessage, Category, ReleaseInfo } from './types';
 import Dashboard from './components/Dashboard';
 import TitleBar from './components/Header';
-import MenuBar from './components/MenuBar';
 // FIX: RepoEditView is a default export, so it should be imported without curly braces.
 import RepoEditView from './components/modals/RepoFormModal';
 import Toast from './components/Toast';
@@ -889,10 +888,10 @@ const App: React.FC = () => {
     <IconContext.Provider value={settings.iconSet}>
       <TooltipProvider>
         <div className="flex flex-col h-screen">
-          <TitleBar activeView={activeView} onSetView={setActiveView} />
-          <MenuBar
-            onNewRepo={() => handleOpenRepoForm('new')}
+          <TitleBar
             activeView={activeView}
+            onSetView={setActiveView}
+            onNewRepo={() => handleOpenRepoForm('new')}
             onCheckAllForUpdates={handleCheckAllForUpdates}
             isCheckingAll={isCheckingAll}
             onToggleAllCategories={toggleAllCategoriesCollapse}

--- a/FUNCTIONAL_MANUAL.md
+++ b/FUNCTIONAL_MANUAL.md
@@ -4,15 +4,14 @@ This manual provides a detailed walkthrough of all the features available in the
 
 ## 1. Navigating the Application
 
-The application features a modern, frameless window design. Navigation and primary actions are split between two main components at the top.
+The application features a modern, frameless window design with a single, information-rich title bar at the top.
 
--   **Title Bar:** The very top bar of the application.
-    -   It displays the application title.
-    -   The entire bar (except for the buttons) is a **draggable region**, allowing you to move the window around your screen.
-    -   The far right contains custom **window controls** to minimize, maximize/restore, and close the application.
--   **Menu Bar:** Located directly below the title bar.
-    -   **Left Side:** Contains buttons for primary dashboard actions like "New Repo", "Check Updates", and "Expand/Collapse All".
-    -   **Right Side:** Houses the main view navigation icons and a quick-toggle button for switching between light and dark themes.
+-   **Title Bar:**
+    -   Displays the application title on the left.
+    -   Hosts the primary dashboard actions ("New Repo", "Check Updates", "Expand/Collapse All") when the dashboard is active, centered for easy access.
+    -   Provides quick navigation icons for the main views and a light/dark theme toggle on the right.
+    -   Keeps a dedicated **draggable region** outside of the interactive controls so you can reposition the window.
+    -   Contains custom **window controls** to minimize, maximize/restore, and close the application.
 
 The three main application views are:
 -   **Dashboard (Home Icon):** The main screen where you can see and interact with all your repository cards.
@@ -25,7 +24,7 @@ A powerful **Command Palette** can be opened at any time with the `Ctrl/Cmd+K` s
 
 The dashboard is the central hub of the application. It displays all your configured repositories as individual cards, now organized into categories. You can run tasks on multiple repositories at the same time. Starting a long build on one project won't stop you from running a quick update on another.
 
-The menu bar contains a **"Check Updates"** button to check all repositories for remote changes, and a button to **Expand/Collapse All** categories for quick layout management.
+The title bar contains a **"Check Updates"** button to check all repositories for remote changes, and a button to **Expand/Collapse All** categories for quick layout management.
 
 ### Organizing with Categories
 
@@ -92,7 +91,7 @@ Tasks (automation scripts) are configured on a per-repository basis.
 
 ### Adding a New Repository
 
-1.  Click the **"New Repo"** button in the menu bar.
+1.  Click the **"New Repo"** button in the title bar.
 2.  The "Add New Repository" view will appear.
 3.  Fill in the repository's details (Name, URL, Local Path, VCS type, etc.). The **Local Path** must be the absolute path to the repository on your computer for real execution to work.
 4.  Click **"Save Repository"**.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This application provides a simple, powerful dashboard to manage and automate th
 
 ## Core Features
 
--   **Custom Frameless Window:** A modern, VSCode-inspired interface with a custom title bar (for window dragging and controls) and a separate menu bar for a clean, spacious layout.
+-   **Custom Frameless Window:** A modern, VSCode-inspired interface with a custom title bar that combines window controls, navigation, and quick actions in a compact layout.
 -   **Centralized Dashboard:** View the status, branch, and build health of all your repositories in one place.
 -   **Customizable Dashboard Categories:** Organize your repositories into collapsible sections with **dual-theme (light/dark) color styling**, a library of predefined themes, full drag-and-drop support (for both repositories and categories), and alternative up/down reorder buttons.
 -   **Multi-VCS Support:** Manage both Git and Subversion (SVN) repositories seamlessly.
@@ -35,7 +35,7 @@ This application provides a simple, powerful dashboard to manage and automate th
 ## Quick Start
 
 1.  **Add a Repository:**
-    -   Click the **"New Repo"** button in the menu bar.
+    -   Click the **"New Repo"** button in the title bar.
     -   Select the Version Control System (Git or SVN).
     -   Fill in the required details on the "General" tab.
     -   Click **"Save Repository"**.

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -18,9 +18,8 @@ The application is split into three main processes, which is standard for Electr
 ### Frameless Window and UI Structure
 The application uses a custom frameless window to achieve a modern, VSCode-like appearance.
 - **`electron/main.ts`:** Configures the `BrowserWindow` with `frame: false` and `titleBarStyle: 'hidden'` to remove the default OS window chrome. It also contains IPC handlers (`window-minimize`, `window-maximize`, `window-close`) to provide functionality for the custom controls.
-- **`components/Header.tsx`:** This component has been repurposed to act as the application's **Title Bar**. It is responsible for displaying the app title and providing a draggable region (`-webkit-app-region: drag`).
+- **`components/Header.tsx`:** This component serves as the application's **Title Bar**. It displays the app title, renders the primary dashboard actions, and provides a draggable region (`-webkit-app-region: drag`).
 - **`components/titlebar/WindowControls.tsx`:** A dedicated component that renders the custom minimize, maximize/restore, and close buttons. It communicates with the main process via IPC to execute window actions.
-- **`components/MenuBar.tsx`:** A new component that sits directly below the title bar. It contains the application's primary actions (e.g., "New Repo") and the main view navigation icons, separating them from the window's structural controls.
 - **`components/CommandPalette.tsx`:** This component is a modal dialog that is opened via a keyboard shortcut (`Ctrl/Cmd+K`). It provides a search-driven interface for users to quickly find and execute commands, such as running tasks or navigating to different views.
 
 ### Main Process

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,6 +6,10 @@ import { CogIcon } from './icons/CogIcon';
 import { InformationCircleIcon } from './icons/InformationCircleIcon';
 import { SunIcon } from './icons/SunIcon';
 import { MoonIcon } from './icons/MoonIcon';
+import { PlusIcon } from './icons/PlusIcon';
+import { CloudArrowDownIcon } from './icons/CloudArrowDownIcon';
+import { ArrowsPointingInIcon } from './icons/ArrowsPointingInIcon';
+import { ArrowsPointingOutIcon } from './icons/ArrowsPointingOutIcon';
 import { useSettings } from '../contexts/SettingsContext';
 import type { AppView } from '../types';
 import { useTooltip } from '../hooks/useTooltip';
@@ -13,11 +17,25 @@ import { useTooltip } from '../hooks/useTooltip';
 interface TitleBarProps {
   activeView: AppView;
   onSetView: (view: AppView) => void;
+  onNewRepo: () => void;
+  onCheckAllForUpdates: () => void;
+  isCheckingAll: boolean;
+  onToggleAllCategories: () => void;
+  canCollapseAll: boolean;
 }
 
-const TitleBar: React.FC<TitleBarProps> = ({ activeView, onSetView }) => {
+const TitleBar: React.FC<TitleBarProps> = ({
+  activeView,
+  onSetView,
+  onNewRepo,
+  onCheckAllForUpdates,
+  isCheckingAll,
+  onToggleAllCategories,
+  canCollapseAll,
+}) => {
   const { settings, saveSettings } = useSettings();
   const isEditing = activeView === 'edit-repository';
+  const isDashboard = activeView === 'dashboard';
 
   const handleToggleTheme = () => {
     const newTheme = settings.theme === 'dark' ? 'light' : 'dark';
@@ -34,11 +52,14 @@ const TitleBar: React.FC<TitleBarProps> = ({ activeView, onSetView }) => {
   const settingsTooltip = useTooltip('Settings');
   const infoTooltip = useTooltip('Information');
   const themeTooltip = useTooltip(`Switch to ${settings.theme === 'dark' ? 'light' : 'dark'} mode`);
+  const newRepoTooltip = useTooltip('Add New Repository');
+  const checkUpdatesTooltip = useTooltip('Check all repositories for updates');
+  const expandCollapseTooltip = useTooltip(canCollapseAll ? 'Collapse all categories' : 'Expand all categories');
 
   return (
     <header
       style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
-      className="bg-gray-200 dark:bg-gray-800/90 h-[var(--title-bar-height)] flex items-center justify-between pl-2 pr-0 flex-shrink-0"
+      className="bg-gray-200 dark:bg-gray-800/90 h-[var(--title-bar-height)] flex items-center gap-2 pl-2 pr-0 flex-shrink-0"
     >
       <div
         className="flex items-center gap-2 text-sm font-semibold text-gray-700 dark:text-gray-300"
@@ -46,6 +67,44 @@ const TitleBar: React.FC<TitleBarProps> = ({ activeView, onSetView }) => {
       >
         <GitBranchIcon className="h-5 w-5 text-blue-600 dark:text-blue-500" />
         <span>Git Automation Dashboard</span>
+      </div>
+      <div
+        className="flex flex-1 items-center justify-center"
+        style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+      >
+        {isDashboard && (
+          <div className="flex items-center gap-1 sm:gap-2">
+            <button
+              {...newRepoTooltip}
+              onClick={onNewRepo}
+              className="flex items-center justify-center gap-1 rounded-md bg-blue-600 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-gray-200 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-offset-gray-700"
+            >
+              <PlusIcon className="h-4 w-4" />
+              <span className="hidden sm:inline">New Repo</span>
+            </button>
+            <button
+              {...checkUpdatesTooltip}
+              onClick={onCheckAllForUpdates}
+              disabled={isCheckingAll}
+              className="flex items-center justify-center gap-1 rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-gray-200 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-offset-gray-700"
+            >
+              <CloudArrowDownIcon className={`h-4 w-4 ${isCheckingAll ? 'animate-pulse' : ''}`} />
+              <span className="hidden sm:inline">{isCheckingAll ? 'Checking…' : 'Check Updates'}</span>
+            </button>
+            <button
+              {...expandCollapseTooltip}
+              onClick={onToggleAllCategories}
+              className="flex items-center justify-center gap-1 rounded-md bg-gray-500 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 focus:ring-offset-gray-200 dark:bg-gray-500 dark:hover:bg-gray-600 dark:focus:ring-offset-gray-700"
+            >
+              {canCollapseAll ? (
+                <ArrowsPointingInIcon className="h-4 w-4" />
+              ) : (
+                <ArrowsPointingOutIcon className="h-4 w-4" />
+              )}
+              <span className="hidden sm:inline">{canCollapseAll ? 'Collapse' : 'Expand'} All</span>
+            </button>
+          </div>
+        )}
       </div>
       <div className="flex items-center" style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}>
         <div className="flex items-center gap-1 pr-1 border-r border-gray-300/60 dark:border-gray-700/60 mr-1">


### PR DESCRIPTION
## Summary
- integrate the New Repo, Check Updates, and Expand/Collapse controls directly into the title bar for more vertical space
- update application documentation to describe the new one-bar layout and instructions for adding repositories

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6d550e7883329cbcdd845be5f26c