### PR TITLE
chore: prepare 0.24.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.1]
+
+### Changed
+- **Release Preparation:** Added a concise checklist in the README and expanded guidance in the Technical Manual so maintainers
+  can confidently run through documentation reviews and release packaging steps for minor updates.
+- **Documentation Review:** Refreshed the Markdown manuals to ensure their instructions and terminology match the current
+  application experience prior to publishing this release.
+
 ## [0.24.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,5 +51,18 @@ This application provides a simple, powerful dashboard to manage and automate th
     -   Find your repository card on the dashboard.
     -   Click a task button or use the task selection menu to run your task.
     -   The resizable log panel will automatically appear at the bottom, showing the progress of your script.
+
+## Release Preparation Checklist
+
+Follow this checklist when preparing a new minor or patch release:
+
+1.  **Bump the Version:** Update the `version` field in `package.json` and ensure any user-facing references match.
+2.  **Review Documentation:** Re-read the README, Functional Manual, Technical Manual, and CHANGELOG to confirm terminology and
+    screenshots reflect the current UI and workflow.
+3.  **Update Release Notes:** Add a new section to `CHANGELOG.md` summarizing the changes included in the release.
+4.  **Build Installers:** Run `npm run pack` to generate platform installers and smoke-test the output locally.
+5.  **Publish on GitHub:** Draft a new GitHub release, attach the generated artifacts, paste the changelog entry as release
+    notes, then publish.
+
 ---
 _For developer information, including how to run this project in development mode or build it from source, please see the **Technical Manual** tab in the Info Hub._

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -87,11 +87,13 @@ All application data, including repositories, categories, and global settings, i
 
 ## 6. Publishing a Release
 
-To publish a new version for manual download:
+Use this process when shipping a new minor update or bugfix:
 
-1.  **Increment Version:** Bump the `version` in `package.json`.
-2.  **Run Pack:** Execute `npm run pack`. This will generate the installers in the `release/` folder.
-3.  **Publish Release:** Go to your repository's "Releases" page on GitHub, create a new release, and upload the generated installer files.
+1.  **Increment the Version:** Update the `version` in `package.json` and verify the README and manuals reference the new number if applicable.
+2.  **Refresh Documentation:** Re-read `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `CHANGELOG.md` to ensure screenshots, feature descriptions, and workflows match the current UI.
+3.  **Update Release Notes:** Add a new entry to `CHANGELOG.md` summarizing the changes. This text can be copied directly into the GitHub release body.
+4.  **Build Installers:** Run `npm run pack`. The command produces platform installers in the `release/` directory. Perform a quick smoke test of the generated artifacts before distribution.
+5.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, paste the changelog entry, and publish.
 ## 7. Automatic Updates
 
 The application is configured to automatically check for updates on startup using the `electron-updater` library.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-automation-dashboard",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "A dashboard to manage and automate the workflow for a set of Git repositories.",
   "main": "dist/main.js",
   "author": "AI Assistant",


### PR DESCRIPTION
## Summary
- bump the application version to 0.24.1 for the upcoming bugfix release
- add a release preparation checklist to the README and expand the technical manual guidance
- document the 0.24.1 notes in the changelog after reviewing the markdown documentation set

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd72fd719883328f23d2c4fc5b4ebb