### PR TITLE
chore: prepare 0.24.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.2]
+
+### Changed
+- **Release Documentation:** Refined the release checklist in the README and Technical Manual to better guide minor and patch
+  releases, emphasizing how to reuse changelog entries for GitHub publishing.
+
+### Fixed
+- **Documentation Drift:** Re-reviewed the Markdown manuals to ensure their wording matches the current release workflow before
+  publishing this bugfix build.
+
 ## [0.24.1]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -56,13 +56,15 @@ This application provides a simple, powerful dashboard to manage and automate th
 
 Follow this checklist when preparing a new minor or patch release:
 
-1.  **Bump the Version:** Update the `version` field in `package.json` and ensure any user-facing references match.
+1.  **Bump the Version:** Update the `version` field in `package.json` and ensure any user-facing references (README, manuals,
+    in-app messaging) match the new number.
 2.  **Review Documentation:** Re-read the README, Functional Manual, Technical Manual, and CHANGELOG to confirm terminology and
     screenshots reflect the current UI and workflow.
-3.  **Update Release Notes:** Add a new section to `CHANGELOG.md` summarizing the changes included in the release.
+3.  **Update Release Notes:** Add a new section to `CHANGELOG.md` summarizing the changes included in the release. This text
+    becomes the body of the GitHub release notes.
 4.  **Build Installers:** Run `npm run pack` to generate platform installers and smoke-test the output locally.
-5.  **Publish on GitHub:** Draft a new GitHub release, attach the generated artifacts, paste the changelog entry as release
-    notes, then publish.
+5.  **Publish on GitHub:** Draft a new GitHub release, attach the generated artifacts, verify the tag/version details, paste the
+    changelog entry into the release body, then publish.
 
 ---
 _For developer information, including how to run this project in development mode or build it from source, please see the **Technical Manual** tab in the Info Hub._

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -89,11 +89,11 @@ All application data, including repositories, categories, and global settings, i
 
 Use this process when shipping a new minor update or bugfix:
 
-1.  **Increment the Version:** Update the `version` in `package.json` and verify the README and manuals reference the new number if applicable.
+1.  **Increment the Version:** Update the `version` in `package.json` and verify the README, manuals, and any in-app references reflect the new number where applicable.
 2.  **Refresh Documentation:** Re-read `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `CHANGELOG.md` to ensure screenshots, feature descriptions, and workflows match the current UI.
-3.  **Update Release Notes:** Add a new entry to `CHANGELOG.md` summarizing the changes. This text can be copied directly into the GitHub release body.
+3.  **Update Release Notes:** Add a new entry to `CHANGELOG.md` summarizing the changes. Plan to reuse this text verbatim in the GitHub release body.
 4.  **Build Installers:** Run `npm run pack`. The command produces platform installers in the `release/` directory. Perform a quick smoke test of the generated artifacts before distribution.
-5.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, paste the changelog entry, and publish.
+5.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, verify the tag/version details, paste the changelog entry into the notes, and publish.
 ## 7. Automatic Updates
 
 The application is configured to automatically check for updates on startup using the `electron-updater` library.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-automation-dashboard",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "A dashboard to manage and automate the workflow for a set of Git repositories.",
   "main": "dist/main.js",
   "author": "AI Assistant",


### PR DESCRIPTION
## Summary
- bump the dashboard version to 0.24.2 for the next patch release
- clarify the release-prep checklists in the README and Technical Manual so notes flow directly into GitHub releases
- capture the documentation refresh in the changelog for 0.24.2

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd7968bb208332b7ef3fd05f065077