### PR TITLE
chore: prepare 0.24.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- _No unreleased changes._
+
+## [0.24.3]
+
 ### Added
-- **Full Release Publishing:** The GitHub release form now includes a release type selector, making it easy to publish full releases in addition to drafts and pre-releases.
+- **Full Release Publishing:** The GitHub release form now includes a release type selector so you can promote a build to a fully published release without leaving the app's workflow.
+
+### Changed
+- **Release Documentation:** Updated the README and Technical Manual checklists to remind maintainers to set the release type appropriately when drafting GitHub releases and to reuse the latest changelog entry for the notes body.
+
+### Fixed
+- **Documentation Drift:** Re-reviewed the Markdown manuals to ensure they reflect the new release publishing controls before packaging this bugfix update.
 
 ## [0.24.2]
 

--- a/FUNCTIONAL_MANUAL.md
+++ b/FUNCTIONAL_MANUAL.md
@@ -129,7 +129,7 @@ Provides a full interface to manage your Git branches. You can:
 #### Releases Tab (Git Only)
 This tab provides a complete interface for managing your project's GitHub releases. It requires a GitHub Personal Access Token to be configured in the global settings. To view and manage draft releases, the token must have repository permissions for **"Contents: Read & write"**.
 - **View Releases:** See a list of all existing releases, each with its name, tag, creation date, and status badges for "Draft" and "Pre-release". The release notes body is also displayed and supports Markdown rendering.
-- **Create Release:** Click the "Create New Release" button to open a form. You can specify a tag name, title, and release notes (in Markdown), and choose whether to publish it immediately as a full release, keep it as a draft, or mark it as a pre-release.
+- **Create Release:** Click the "Create New Release" button to open a form. You can specify a tag name, title, and release notes (in Markdown), and use the **Release Type** selector to publish immediately as a full release, keep it as a draft, or mark it as a pre-release.
 - **Edit Release:** Click the "Edit" button on any release to modify its details.
 - **Publish/Unpublish:** Quickly toggle a release's draft status.
 - **Toggle Pre-release:** Change a release from a stable to a pre-release and vice-versa.

--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ Follow this checklist when preparing a new minor or patch release:
     in-app messaging) match the new number.
 2.  **Review Documentation:** Re-read the README, Functional Manual, Technical Manual, and CHANGELOG to confirm terminology and
     screenshots reflect the current UI and workflow.
-3.  **Update Release Notes:** Add a new section to `CHANGELOG.md` summarizing the changes included in the release. This text
-    becomes the body of the GitHub release notes.
+3.  **Update Release Notes:** Add a new section to `CHANGELOG.md` summarizing the changes included in the release. Plan to reuse
+    this text verbatim in the GitHub release body.
 4.  **Build Installers:** Run `npm run pack` to generate platform installers and smoke-test the output locally.
-5.  **Publish on GitHub:** Draft a new GitHub release, attach the generated artifacts, verify the tag/version details, paste the
-    changelog entry into the release body, then publish.
+5.  **Publish on GitHub:** Draft a new GitHub release, attach the generated artifacts, verify the tag/version details, choose the
+    correct value in the **Release Type** selector (Full Release, Draft, or Pre-release), paste the changelog entry into the release
+    body, then publish.
 
 ---
 _For developer information, including how to run this project in development mode or build it from source, please see the **Technical Manual** tab in the Info Hub._

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -93,7 +93,7 @@ Use this process when shipping a new minor update or bugfix:
 2.  **Refresh Documentation:** Re-read `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `CHANGELOG.md` to ensure screenshots, feature descriptions, and workflows match the current UI.
 3.  **Update Release Notes:** Add a new entry to `CHANGELOG.md` summarizing the changes. Plan to reuse this text verbatim in the GitHub release body.
 4.  **Build Installers:** Run `npm run pack`. The command produces platform installers in the `release/` directory. Perform a quick smoke test of the generated artifacts before distribution.
-5.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, verify the tag/version details, paste the changelog entry into the notes, and publish.
+5.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, verify the tag/version details, choose the appropriate option in the **Release Type** selector (Full Release, Draft, or Pre-release), paste the changelog entry into the notes, and publish.
 ## 7. Automatic Updates
 
 The application is configured to automatically check for updates on startup using the `electron-updater` library.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-automation-dashboard",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "description": "A dashboard to manage and automate the workflow for a set of Git repositories.",
   "main": "dist/main.js",
   "author": "AI Assistant",


### PR DESCRIPTION
## Summary
- bump the application version to 0.24.3 in preparation for the next release
- document the new Release Type selector in the README, Technical Manual, and Functional Manual checklists
- promote the pending changelog entry into a 0.24.3 section with updated release guidance

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd7ec8a02483328f5d247ea6d91aef