### PR TITLE
chore: prepare v0.24.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 - _No unreleased changes._
 
+## [0.24.4]
+
+### Changed
+- **Release Preparation Docs:** Clarified the README and Technical Manual checklists to explicitly set the Release Type selector
+  during publishing and to reuse the freshly written changelog entry for the GitHub release body.
+
+### Fixed
+- **Version Metadata:** Incremented the application version to `0.24.4` in `package.json` ahead of publishing this patch build.
+
 ## [0.24.3]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Follow this checklist when preparing a new minor or patch release:
 3.  **Update Release Notes:** Add a new section to `CHANGELOG.md` summarizing the changes included in the release. Plan to reuse
     this text verbatim in the GitHub release body.
 4.  **Build Installers:** Run `npm run pack` to generate platform installers and smoke-test the output locally.
-5.  **Publish on GitHub:** Draft a new GitHub release, attach the generated artifacts, verify the tag/version details, choose the
-    correct value in the **Release Type** selector (Full Release, Draft, or Pre-release), paste the changelog entry into the release
-    body, then publish.
+5.  **Publish on GitHub:** Draft a new GitHub release, attach the generated artifacts, verify the tag/version details, and set the
+    **Release Type** selector to the intended state (Full Release for GA builds, Draft or Pre-release as needed). Paste the freshly
+    written changelog entry into the release body so the GitHub notes exactly match the repository history, then publish.
 
 ---
 _For developer information, including how to run this project in development mode or build it from source, please see the **Technical Manual** tab in the Info Hub._

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -93,7 +93,7 @@ Use this process when shipping a new minor update or bugfix:
 2.  **Refresh Documentation:** Re-read `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `CHANGELOG.md` to ensure screenshots, feature descriptions, and workflows match the current UI.
 3.  **Update Release Notes:** Add a new entry to `CHANGELOG.md` summarizing the changes. Plan to reuse this text verbatim in the GitHub release body.
 4.  **Build Installers:** Run `npm run pack`. The command produces platform installers in the `release/` directory. Perform a quick smoke test of the generated artifacts before distribution.
-5.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, verify the tag/version details, choose the appropriate option in the **Release Type** selector (Full Release, Draft, or Pre-release), paste the changelog entry into the notes, and publish.
+5.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, verify the tag/version details, and explicitly set the **Release Type** selector to match your intent (Full Release for GA builds or Draft/Pre-release when staging). Paste the current changelog entry into the notes so the GitHub release matches the repository history, then publish.
 ## 7. Automatic Updates
 
 The application is configured to automatically check for updates on startup using the `electron-updater` library.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-automation-dashboard",
-  "version": "0.24.3",
+  "version": "0.24.4",
   "description": "A dashboard to manage and automate the workflow for a set of Git repositories.",
   "main": "dist/main.js",
   "author": "AI Assistant",


### PR DESCRIPTION
## Summary
- bump the application version metadata to 0.24.4 for the upcoming patch release
- document the 0.24.4 changes in the changelog to capture the release preparation work
- clarify the README and Technical Manual publishing steps to reinforce selecting the correct Release Type and reusing the changelog entry in GitHub

## Testing
- not run (documentation and metadata updates only)

------
https://chatgpt.com/codex/tasks/task_e_68dd831ae96c83328dd0d44615ab02c2