### PR TITLE
Add detected executable suggestions to launch command input

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -908,16 +908,17 @@ const App: React.FC = () => {
                     return <InfoView />;
                   case 'edit-repository':
                     // The key ensures the component re-mounts when switching between editing different repos
-                    return <RepoEditView 
-                      key={repoFormState.repoId} 
-                      repository={repositoryToEdit} 
-                      onSave={handleSaveRepo} 
+                    return <RepoEditView
+                      key={repoFormState.repoId}
+                      repository={repositoryToEdit}
+                      onSave={handleSaveRepo}
                       onCancel={handleCloseRepoForm}
                       onRefreshState={refreshRepoState}
                       setToast={setToast}
                       confirmAction={confirmAction}
                       defaultCategoryId={repoFormState.defaultCategoryId}
                       onOpenWeblink={handleOpenWeblink}
+                      detectedExecutables={detectedExecutables}
                     />;
                   case 'dashboard':
                   default:


### PR DESCRIPTION
## Summary
- pass the detected executable list to the repository editor
- surface detected executables as sorted command suggestions when configuring launch commands
- show helper text to clarify where the suggestions originate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de9367b80c83328a2d53781d2a57c4