### PR TITLE
chore: prepare 0.24.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 - _No unreleased changes._
 
+## [0.24.5]
+
+### Changed
+- **Release Process Guidance:** Clarified the README and Technical Manual checklists to explicitly record documentation reviews in the changelog so maintainers have an audit trail when preparing releases.
+
+### Fixed
+- **Version Metadata:** Incremented the application version to `0.24.5` in `package.json` ahead of publishing this patch build.
+
 ## [0.24.4]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 ## [0.24.5]
 
 ### Changed
-- **Release Process Guidance:** Clarified the README and Technical Manual checklists to explicitly record documentation reviews in the changelog so maintainers have an audit trail when preparing releases.
+- **Release Process Guidance:** Clarified the README and Technical Manual checklists to explicitly record documentation reviews in the changelog and to require running automated tests before packaging so maintainers have an auditable release workflow.
 
 ### Fixed
 - **Version Metadata:** Incremented the application version to `0.24.5` in `package.json` ahead of publishing this patch build.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ Follow this checklist when preparing a new minor or patch release:
     review is recorded.
 3.  **Update Release Notes:** Add a new section to `CHANGELOG.md` summarizing the changes included in the release, including
     any documentation adjustments or reminders for maintainers. Plan to reuse this text verbatim in the GitHub release body.
-4.  **Build Installers:** Run `npm run pack` to generate platform installers and smoke-test the output locally.
-5.  **Publish on GitHub:** Draft a new GitHub release, attach the generated artifacts, verify the tag/version details, and set the
+4.  **Run Automated Checks:** Execute `npm test` (or the appropriate suite documented in the Technical Manual) and confirm it completes successfully before packaging.
+5.  **Build Installers:** Run `npm run pack` to generate platform installers and smoke-test the output locally.
+6.  **Publish on GitHub:** Draft a new GitHub release, attach the generated artifacts, verify the tag/version details, and set the
     **Release Type** selector to the intended state (Full Release for GA builds, Draft or Pre-release as needed). Paste the freshly
     written changelog entry into the release body so the GitHub notes exactly match the repository history, then publish.
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ Follow this checklist when preparing a new minor or patch release:
 1.  **Bump the Version:** Update the `version` field in `package.json` and ensure any user-facing references (README, manuals,
     in-app messaging) match the new number.
 2.  **Review Documentation:** Re-read the README, Functional Manual, Technical Manual, and CHANGELOG to confirm terminology and
-    screenshots reflect the current UI and workflow.
-3.  **Update Release Notes:** Add a new section to `CHANGELOG.md` summarizing the changes included in the release. Plan to reuse
-    this text verbatim in the GitHub release body.
+    screenshots reflect the current UI and workflow. Capture any documentation-only tweaks in the upcoming changelog entry so the
+    review is recorded.
+3.  **Update Release Notes:** Add a new section to `CHANGELOG.md` summarizing the changes included in the release, including
+    any documentation adjustments or reminders for maintainers. Plan to reuse this text verbatim in the GitHub release body.
 4.  **Build Installers:** Run `npm run pack` to generate platform installers and smoke-test the output locally.
 5.  **Publish on GitHub:** Draft a new GitHub release, attach the generated artifacts, verify the tag/version details, and set the
     **Release Type** selector to the intended state (Full Release for GA builds, Draft or Pre-release as needed). Paste the freshly

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -90,8 +90,8 @@ All application data, including repositories, categories, and global settings, i
 Use this process when shipping a new minor update or bugfix:
 
 1.  **Increment the Version:** Update the `version` in `package.json` and verify the README, manuals, and any in-app references reflect the new number where applicable.
-2.  **Refresh Documentation:** Re-read `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `CHANGELOG.md` to ensure screenshots, feature descriptions, and workflows match the current UI.
-3.  **Update Release Notes:** Add a new entry to `CHANGELOG.md` summarizing the changes. Plan to reuse this text verbatim in the GitHub release body.
+2.  **Refresh Documentation:** Re-read `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `CHANGELOG.md` to ensure screenshots, feature descriptions, and workflows match the current UI. Note any documentation-only edits in the changelog so the audit trail is preserved.
+3.  **Update Release Notes:** Add a new entry to `CHANGELOG.md` summarizing the changes, calling out documentation adjustments alongside any fixes or features. Plan to reuse this text verbatim in the GitHub release body.
 4.  **Build Installers:** Run `npm run pack`. The command produces platform installers in the `release/` directory. Perform a quick smoke test of the generated artifacts before distribution.
 5.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, verify the tag/version details, and explicitly set the **Release Type** selector to match your intent (Full Release for GA builds or Draft/Pre-release when staging). Paste the current changelog entry into the notes so the GitHub release matches the repository history, then publish.
 ## 7. Automatic Updates

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -92,8 +92,9 @@ Use this process when shipping a new minor update or bugfix:
 1.  **Increment the Version:** Update the `version` in `package.json` and verify the README, manuals, and any in-app references reflect the new number where applicable.
 2.  **Refresh Documentation:** Re-read `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `CHANGELOG.md` to ensure screenshots, feature descriptions, and workflows match the current UI. Note any documentation-only edits in the changelog so the audit trail is preserved.
 3.  **Update Release Notes:** Add a new entry to `CHANGELOG.md` summarizing the changes, calling out documentation adjustments alongside any fixes or features. Plan to reuse this text verbatim in the GitHub release body.
-4.  **Build Installers:** Run `npm run pack`. The command produces platform installers in the `release/` directory. Perform a quick smoke test of the generated artifacts before distribution.
-5.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, verify the tag/version details, and explicitly set the **Release Type** selector to match your intent (Full Release for GA builds or Draft/Pre-release when staging). Paste the current changelog entry into the notes so the GitHub release matches the repository history, then publish.
+4.  **Run Automated Checks:** Execute `npm test` (or the broader QA suite defined for the project) and confirm a passing result before packaging binaries.
+5.  **Build Installers:** Run `npm run pack`. The command produces platform installers in the `release/` directory. Perform a quick smoke test of the generated artifacts before distribution.
+6.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, verify the tag/version details, and explicitly set the **Release Type** selector to match your intent (Full Release for GA builds or Draft/Pre-release when staging). Paste the current changelog entry into the notes so the GitHub release matches the repository history, then publish.
 ## 7. Automatic Updates
 
 The application is configured to automatically check for updates on startup using the `electron-updater` library.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-automation-dashboard",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "A dashboard to manage and automate the workflow for a set of Git repositories.",
   "main": "dist/main.js",
   "author": "AI Assistant",


### PR DESCRIPTION
## Summary
- bump the application version to 0.24.5 for the upcoming patch release
- refresh the README and Technical Manual release checklists to document the required changelog updates when auditing docs
- capture the version bump and documentation guidance in the changelog for reuse in the GitHub release notes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68debf3450308332b6303c45c8ba585b