### PR TITLE
Adjust restore window icon styling

### DIFF
--- a/components/icons/RestoreIcon.tsx
+++ b/components/icons/RestoreIcon.tsx
@@ -1,9 +1,17 @@
 import React from 'react';
 
 const RestoreIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
- <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" {...props}>
-  <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 8.25V6a2.25 2.25 0 00-2.25-2.25H6A2.25 2.25 0 003.75 6v8.25A2.25 2.25 0 006 16.5h2.25m8.25-8.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-8.25A2.25 2.25 0 017.5 18v-2.25m8.25-8.25l-6 6" />
-</svg>
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={2}
+        stroke="currentColor"
+        {...props}
+    >
+        <rect x={9} y={4.5} width={10.5} height={10.5} rx={2} ry={2} />
+        <rect x={4.5} y={9} width={10.5} height={10.5} rx={2} ry={2} />
+    </svg>
 );
 
 export { RestoreIcon };


### PR DESCRIPTION
## Summary
- replace the restore window control glyph with overlapping rectangles to better match the Windows-style iconography

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dec2aa51848332b259c8a10c1f882c