### PR TITLE
Add configurable automatic repository update checks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import LaunchSelectionModal from './components/modals/LaunchSelectionModal';
 import CommitHistoryModal from './components/modals/CommitHistoryModal';
 import ExecutableSelectionModal from './components/modals/ExecutableSelectionModal';
 import { VcsType } from './types';
+import { MIN_AUTO_CHECK_INTERVAL_SECONDS } from './constants';
 import { TooltipProvider } from './contexts/TooltipContext';
 import Tooltip from './components/Tooltip';
 import { useLogger } from './hooks/useLogger';
@@ -493,10 +494,13 @@ const App: React.FC = () => {
       return;
     }
 
-    const intervalMinutes = Math.max(1, settings.repoUpdateCheckInterval || 0);
-    const intervalMs = intervalMinutes * 60 * 1000;
+    const intervalSeconds = Math.max(
+      MIN_AUTO_CHECK_INTERVAL_SECONDS,
+      settings.repoUpdateCheckInterval || 0,
+    );
+    const intervalMs = intervalSeconds * 1000;
 
-    logger.info('Enabling automatic repository update checks.', { intervalMinutes });
+    logger.info('Enabling automatic repository update checks.', { intervalSeconds });
 
     const runAutoCheck = () => {
       const repos = repositoriesRef.current;

--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useRepositoryManager } from './hooks/useRepositoryManager';
 // FIX: Add missing ReleaseInfo type to the import.
 import type { Repository, GlobalSettings, AppView, Task, LogEntry, LocalPathState, Launchable, LaunchConfig, DetailedStatus, BranchInfo, UpdateStatusMessage, ToastMessage, Category, ReleaseInfo } from './types';
@@ -79,6 +79,16 @@ const App: React.FC = () => {
   const [detectedExecutables, setDetectedExecutables] = useState<Record<string, string[]>>({});
   const [appVersion, setAppVersion] = useState<string>('');
   const [isCheckingAll, setIsCheckingAll] = useState(false);
+
+  const repositoriesRef = useRef(repositories);
+  useEffect(() => {
+    repositoriesRef.current = repositories;
+  }, [repositories]);
+
+  const localPathStatesRef = useRef(localPathStates);
+  useEffect(() => {
+    localPathStatesRef.current = localPathStates;
+  }, [localPathStates]);
   const [updateReady, setUpdateReady] = useState(false);
 
   // New states for deeper VCS integration
@@ -434,28 +444,79 @@ const App: React.FC = () => {
     }
   }, [contextMenu.isOpen, handleCloseContextMenu]);
 
-  const handleCheckAllForUpdates = useCallback(async () => {
+  const handleCheckAllForUpdates = useCallback(async ({ silent = false }: { silent?: boolean } = {}) => {
+    if (isCheckingAll) {
+      if (silent) {
+        logger.debug('Skipping update check because one is already in progress.');
+      } else {
+        setToast({ message: 'Already checking repositories for updates.', type: 'info' });
+      }
+      return;
+    }
     const validRepos = repositories.filter(r => localPathStates[r.id] === 'valid');
     if (validRepos.length === 0) {
-      setToast({ message: 'No repositories with valid local paths to check.', type: 'info' });
+      if (silent) {
+        logger.debug('Skipping automatic update check: no repositories with valid local paths.');
+      } else {
+        setToast({ message: 'No repositories with valid local paths to check.', type: 'info' });
+      }
       return;
     }
 
     setIsCheckingAll(true);
-    setToast({ message: `Checking ${validRepos.length} repositories for updates...`, type: 'info' });
+    if (silent) {
+      logger.debug('Automatically checking repositories for updates.', { count: validRepos.length });
+    } else {
+      setToast({ message: `Checking ${validRepos.length} repositories for updates...`, type: 'info' });
+    }
 
     const updatePromises = validRepos.map(repo => refreshRepoState(repo.id));
-    
+
     try {
         await Promise.all(updatePromises);
-        setToast({ message: 'Update check complete.', type: 'success' });
+        if (silent) {
+          logger.debug('Automatic repository update check completed successfully.');
+        } else {
+          setToast({ message: 'Update check complete.', type: 'success' });
+        }
     } catch (e: any) {
         logger.error('An error occurred during the update check for all repos.', { error: e.message });
         setToast({ message: 'An error occurred during update check.', type: 'error' });
     } finally {
         setIsCheckingAll(false);
     }
-  }, [repositories, localPathStates, refreshRepoState, logger]);
+  }, [repositories, localPathStates, refreshRepoState, logger, isCheckingAll]);
+
+  useEffect(() => {
+    if (!settings.autoCheckRepoUpdates) {
+      logger.debug('Automatic repository update checks are disabled.');
+      return;
+    }
+
+    const intervalMinutes = Math.max(1, settings.repoUpdateCheckInterval || 0);
+    const intervalMs = intervalMinutes * 60 * 1000;
+
+    logger.info('Enabling automatic repository update checks.', { intervalMinutes });
+
+    const runAutoCheck = () => {
+      const repos = repositoriesRef.current;
+      const paths = localPathStatesRef.current;
+      const hasValidRepo = repos.some(repo => paths[repo.id] === 'valid');
+      if (!hasValidRepo) {
+        logger.debug('Skipping automatic update check: no repositories with valid local paths.');
+        return;
+      }
+      handleCheckAllForUpdates({ silent: true });
+    };
+
+    const intervalId = window.setInterval(runAutoCheck, intervalMs);
+    runAutoCheck();
+
+    return () => {
+      logger.info('Disabling automatic repository update checks.', { reason: 'cleanup' });
+      window.clearInterval(intervalId);
+    };
+  }, [settings.autoCheckRepoUpdates, settings.repoUpdateCheckInterval, handleCheckAllForUpdates, logger]);
 
   const handleSwitchBranch = useCallback(async (repoId: string, branch: string) => {
     const repo = repositories.find(r => r.id === repoId);

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -272,6 +272,23 @@ const SettingsView: React.FC<SettingsViewProps> = ({ onSave, currentSettings, se
                     <label className="flex items-start gap-3"><input type="checkbox" name="simulationMode" checked={settings.simulationMode} onChange={handleChange} className="mt-1 focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded"/><div>Enable Simulation Mode<p className="text-xs text-gray-500">If enabled, no real commands are run.</p></div></label>
                     <label className="flex items-start gap-3"><input type="checkbox" name="allowPrerelease" checked={settings.allowPrerelease} onChange={handleChange} className="mt-1 focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded"/><div>Check for Pre-Releases<p className="text-xs text-gray-500">Include beta versions in auto-updates.</p></div></label>
                     <label className="flex items-start gap-3"><input type="checkbox" name="debugLogging" checked={settings.debugLogging} onChange={handleChange} className="mt-1 focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded"/><div>Enable Debug Logging<p className="text-xs text-gray-500">Verbose logging for troubleshooting.</p></div></label>
+                    <div className="space-y-2">
+                      <label className="flex items-start gap-3"><input type="checkbox" name="autoCheckRepoUpdates" checked={settings.autoCheckRepoUpdates} onChange={handleChange} className="mt-1 focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded"/><div>Automatically Check Repositories<p className="text-xs text-gray-500">Periodically refresh repository status information.</p></div></label>
+                      <label className="block">
+                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Check Interval (minutes)</span>
+                        <input
+                          type="number"
+                          name="repoUpdateCheckInterval"
+                          min={1}
+                          max={1440}
+                          value={settings.repoUpdateCheckInterval}
+                          onChange={handleChange}
+                          disabled={!settings.autoCheckRepoUpdates}
+                          className="mt-1 block w-full border-gray-300 dark:border-gray-600 rounded-md shadow-sm bg-gray-50 dark:bg-gray-900 disabled:opacity-60 disabled:cursor-not-allowed"
+                        />
+                        <p className="mt-1 text-xs text-gray-500">Disable automatic checks using the toggle above.</p>
+                      </label>
+                    </div>
                 </div>
              </div>
 

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -13,6 +13,7 @@ import { ClipboardDocumentIcon } from './icons/ClipboardDocumentIcon';
 import { KeyboardIcon } from './icons/KeyboardIcon';
 import KeyboardShortcutEditor from './settings/KeyboardShortcutEditor';
 import { createDefaultKeyboardShortcutSettings } from '../keyboardShortcuts';
+import { MIN_AUTO_CHECK_INTERVAL_SECONDS, MAX_AUTO_CHECK_INTERVAL_SECONDS } from '../constants';
 
 interface SettingsViewProps {
   onSave: (settings: GlobalSettings) => void;
@@ -275,18 +276,21 @@ const SettingsView: React.FC<SettingsViewProps> = ({ onSave, currentSettings, se
                     <div className="space-y-2">
                       <label className="flex items-start gap-3"><input type="checkbox" name="autoCheckRepoUpdates" checked={settings.autoCheckRepoUpdates} onChange={handleChange} className="mt-1 focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 dark:border-gray-600 rounded"/><div>Automatically Check Repositories<p className="text-xs text-gray-500">Periodically refresh repository status information.</p></div></label>
                       <label className="block">
-                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Check Interval (minutes)</span>
+                        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Check Interval (seconds)</span>
                         <input
                           type="number"
                           name="repoUpdateCheckInterval"
-                          min={1}
-                          max={1440}
+                          min={MIN_AUTO_CHECK_INTERVAL_SECONDS}
+                          max={MAX_AUTO_CHECK_INTERVAL_SECONDS}
                           value={settings.repoUpdateCheckInterval}
                           onChange={handleChange}
                           disabled={!settings.autoCheckRepoUpdates}
                           className="mt-1 block w-full border-gray-300 dark:border-gray-600 rounded-md shadow-sm bg-gray-50 dark:bg-gray-900 disabled:opacity-60 disabled:cursor-not-allowed"
                         />
-                        <p className="mt-1 text-xs text-gray-500">Disable automatic checks using the toggle above.</p>
+                        <p className="mt-1 text-xs text-gray-500">
+                          Disable automatic checks using the toggle above. Allowed range:{' '}
+                          {MIN_AUTO_CHECK_INTERVAL_SECONDS}-{MAX_AUTO_CHECK_INTERVAL_SECONDS} seconds.
+                        </p>
                       </label>
                     </div>
                 </div>

--- a/constants.ts
+++ b/constants.ts
@@ -14,3 +14,6 @@ export const BUILD_HEALTH_COLORS: Record<BuildHealth, string> = {
   [BuildHealth.Failing]: 'text-red-600 dark:text-red-500',
   [BuildHealth.Unknown]: 'text-gray-400',
 };
+
+export const MIN_AUTO_CHECK_INTERVAL_SECONDS = 5;
+export const MAX_AUTO_CHECK_INTERVAL_SECONDS = 86400;

--- a/contexts/SettingsContext.tsx
+++ b/contexts/SettingsContext.tsx
@@ -43,6 +43,8 @@ const DEFAULTS: GlobalSettings = {
     zoomFactor: 1,
     saveTaskLogs: true,
     taskLogPath: '',
+    autoCheckRepoUpdates: false,
+    repoUpdateCheckInterval: 30,
     keyboardShortcuts: createDefaultKeyboardShortcutSettings(),
 };
 

--- a/contexts/SettingsContext.tsx
+++ b/contexts/SettingsContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useState, useCallback, ReactNode, useMemo, useEff
 // FIX: Import DropTarget type for DnD operations.
 import type { GlobalSettings, Repository, Category, DropTarget } from '../types';
 import { RepoStatus, BuildHealth, VcsType, TaskStepType } from '../types';
+import { MIN_AUTO_CHECK_INTERVAL_SECONDS, MAX_AUTO_CHECK_INTERVAL_SECONDS } from '../constants';
 import { useLogger } from '../hooks/useLogger';
 import { createDefaultKeyboardShortcutSettings, mergeKeyboardShortcutSettings } from '../keyboardShortcuts';
 
@@ -44,9 +45,16 @@ const DEFAULTS: GlobalSettings = {
     saveTaskLogs: true,
     taskLogPath: '',
     autoCheckRepoUpdates: false,
-    repoUpdateCheckInterval: 30,
+    repoUpdateCheckInterval: 1800,
+    repoUpdateCheckIntervalUnit: 'seconds',
     keyboardShortcuts: createDefaultKeyboardShortcutSettings(),
 };
+
+const clampRepoUpdateInterval = (value: number) =>
+  Math.max(
+    MIN_AUTO_CHECK_INTERVAL_SECONDS,
+    Math.min(MAX_AUTO_CHECK_INTERVAL_SECONDS, Math.round(value || 0)),
+  );
 
 const initialState: AppDataContextState = {
   settings: DEFAULTS,
@@ -331,8 +339,24 @@ export const SettingsProvider: React.FC<{ children: ReactNode }> = ({ children }
   useEffect(() => {
     if (window.electronAPI?.getAllData) {
       window.electronAPI.getAllData().then(data => {
-          const loadedSettings = data.globalSettings ? { ...DEFAULTS, ...data.globalSettings } : { ...DEFAULTS, keyboardShortcuts: createDefaultKeyboardShortcutSettings() };
-          loadedSettings.keyboardShortcuts = mergeKeyboardShortcutSettings(data.globalSettings?.keyboardShortcuts ?? loadedSettings.keyboardShortcuts);
+          const loadedSettings = data.globalSettings
+            ? { ...DEFAULTS, ...data.globalSettings }
+            : { ...DEFAULTS, keyboardShortcuts: createDefaultKeyboardShortcutSettings() };
+          loadedSettings.keyboardShortcuts = mergeKeyboardShortcutSettings(
+            data.globalSettings?.keyboardShortcuts ?? loadedSettings.keyboardShortcuts,
+          );
+
+          const hasSecondsUnit = !!data.globalSettings && 'repoUpdateCheckIntervalUnit' in data.globalSettings;
+          if (!hasSecondsUnit && data.globalSettings?.repoUpdateCheckInterval !== undefined) {
+            loadedSettings.repoUpdateCheckInterval = clampRepoUpdateInterval(
+              loadedSettings.repoUpdateCheckInterval * 60,
+            );
+          } else {
+            loadedSettings.repoUpdateCheckInterval = clampRepoUpdateInterval(
+              loadedSettings.repoUpdateCheckInterval,
+            );
+          }
+          loadedSettings.repoUpdateCheckIntervalUnit = 'seconds';
           const migratedRepos = migrateRepositories(data.repositories || [], loadedSettings);
           
           setSettings(loadedSettings);
@@ -372,7 +396,12 @@ export const SettingsProvider: React.FC<{ children: ReactNode }> = ({ children }
   }, [settings, repositories, categories, uncategorizedOrder, isLoading]);
 
   const saveSettings = useCallback((newSettings: GlobalSettings) => {
-    setSettings(newSettings);
+    setSettings(prev => ({
+      ...prev,
+      ...newSettings,
+      repoUpdateCheckInterval: clampRepoUpdateInterval(newSettings.repoUpdateCheckInterval),
+      repoUpdateCheckIntervalUnit: 'seconds',
+    }));
   }, []);
   
   const addRepository = useCallback((repoData: Omit<Repository, 'id' | 'status' | 'lastUpdated' | 'buildHealth'>, categoryId?: string) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,6 +9,7 @@ import { TaskStepType, LogLevel, VcsType as VcsTypeEnum } from '../types';
 import fsSync from 'fs';
 import JSZip from 'jszip';
 import { createDefaultKeyboardShortcutSettings, mergeKeyboardShortcutSettings } from '../keyboardShortcuts';
+import { MIN_AUTO_CHECK_INTERVAL_SECONDS, MAX_AUTO_CHECK_INTERVAL_SECONDS } from '../constants';
 
 
 declare const require: (id: string) => any;
@@ -107,9 +108,16 @@ const DEFAULTS: GlobalSettings = {
     saveTaskLogs: true,
     taskLogPath: '',
     autoCheckRepoUpdates: false,
-    repoUpdateCheckInterval: 30,
+    repoUpdateCheckInterval: 1800,
+    repoUpdateCheckIntervalUnit: 'seconds',
     keyboardShortcuts: createDefaultKeyboardShortcutSettings(),
 };
+
+const clampRepoUpdateInterval = (value: number) =>
+  Math.max(
+    MIN_AUTO_CHECK_INTERVAL_SECONDS,
+    Math.min(MAX_AUTO_CHECK_INTERVAL_SECONDS, Math.round(value || 0)),
+  );
 
 async function readSettings(): Promise<GlobalSettings> {
     if (globalSettingsCache) {
@@ -121,6 +129,13 @@ async function readSettings(): Promise<GlobalSettings> {
         if (parsedData && parsedData.globalSettings) {
             const settings = { ...DEFAULTS, ...parsedData.globalSettings };
             settings.keyboardShortcuts = mergeKeyboardShortcutSettings(parsedData.globalSettings.keyboardShortcuts ?? settings.keyboardShortcuts);
+            const hasSecondsUnit = 'repoUpdateCheckIntervalUnit' in parsedData.globalSettings;
+            if (!hasSecondsUnit && parsedData.globalSettings.repoUpdateCheckInterval !== undefined) {
+                settings.repoUpdateCheckInterval = clampRepoUpdateInterval(settings.repoUpdateCheckInterval * 60);
+            } else {
+                settings.repoUpdateCheckInterval = clampRepoUpdateInterval(settings.repoUpdateCheckInterval);
+            }
+            settings.repoUpdateCheckIntervalUnit = 'seconds';
             globalSettingsCache = settings;
             return settings;
         }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -106,6 +106,8 @@ const DEFAULTS: GlobalSettings = {
     zoomFactor: 1,
     saveTaskLogs: true,
     taskLogPath: '',
+    autoCheckRepoUpdates: false,
+    repoUpdateCheckInterval: 30,
     keyboardShortcuts: createDefaultKeyboardShortcutSettings(),
 };
 

--- a/types.ts
+++ b/types.ts
@@ -167,6 +167,8 @@ export interface GlobalSettings {
   zoomFactor: number;
   saveTaskLogs: boolean;
   taskLogPath: string;
+  autoCheckRepoUpdates: boolean;
+  repoUpdateCheckInterval: number;
   keyboardShortcuts: KeyboardShortcutSettings;
 }
 

--- a/types.ts
+++ b/types.ts
@@ -169,6 +169,7 @@ export interface GlobalSettings {
   taskLogPath: string;
   autoCheckRepoUpdates: boolean;
   repoUpdateCheckInterval: number;
+  repoUpdateCheckIntervalUnit: 'seconds';
   keyboardShortcuts: KeyboardShortcutSettings;
 }
 


### PR DESCRIPTION
## Summary
- add global settings fields to toggle automatic repository status checks and configure the refresh interval
- expose the new options in the settings UI and default them in both renderer and main process
- trigger silent background refreshes on the configured cadence while respecting manual check feedback

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dec3189274833281af0656b2b8eb8e