### PR TITLE
Allow manual update checks during automatic polling

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -82,9 +82,9 @@ const TitleBar: React.FC<TitleBarProps> = ({
             <button
               {...checkUpdatesTooltip}
               onClick={onCheckAllForUpdates}
-              disabled={isCheckingAll}
               style={noDragStyle}
-              className="flex items-center justify-center gap-1 rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-gray-200 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-offset-gray-700"
+              aria-disabled={isCheckingAll}
+              className={`flex items-center justify-center gap-1 rounded-md bg-green-600 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 focus:ring-offset-gray-200 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-offset-gray-700 ${isCheckingAll ? 'opacity-70 cursor-progress' : ''}`}
             >
               <CloudArrowDownIcon className={`h-4 w-4 ${isCheckingAll ? 'animate-pulse' : ''}`} />
               <span className="hidden sm:inline">{isCheckingAll ? 'Checking…' : 'Check Updates'}</span>

--- a/components/MenuBar.tsx
+++ b/components/MenuBar.tsx
@@ -39,8 +39,9 @@ const MenuBar: React.FC<MenuBarProps> = ({ onNewRepo, activeView, onCheckAllForU
                 <button
                   {...checkUpdatesTooltip}
                   onClick={onCheckAllForUpdates}
-                  disabled={isCheckingAll || isEditing}
-                  className="flex items-center justify-center px-3 py-1.5 sm:px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 dark:focus:ring-offset-gray-800 focus:ring-green-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  disabled={isEditing}
+                  aria-disabled={isCheckingAll}
+                  className={`flex items-center justify-center px-3 py-1.5 sm:px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 dark:focus:ring-offset-gray-800 focus:ring-green-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${isCheckingAll ? 'opacity-70 cursor-progress' : ''}`}
                 >
                   <CloudArrowDownIcon className={`h-5 w-5 mr-0 sm:mr-2 ${isCheckingAll ? 'animate-pulse' : ''}`} />
                   <span className="hidden sm:inline">{isCheckingAll ? 'Checking...' : 'Check Updates'}</span>


### PR DESCRIPTION
## Summary
- keep the Check Updates controls clickable even while an automatic update check is running
- indicate in the UI that an automatic check is in progress without fully disabling the buttons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dec8f2ab748332960162873b130981