### PR TITLE
Fix branch dropdown computation order to prevent startup crash

### DIFF
--- a/components/RepositoryCard.tsx
+++ b/components/RepositoryCard.tsx
@@ -84,56 +84,6 @@ const BranchSwitcher: React.FC<{
     const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
     const [isModalOpen, setIsModalOpen] = useState(false);
     
-    const computeDropdownMetrics = useCallback(() => {
-        if (!isOpen || !buttonRef.current) return;
-
-        const rect = buttonRef.current.getBoundingClientRect();
-        const dropdownHeight = 240; // Estimated height for max-h-60
-
-        let top: number;
-
-        // Position vertically: open upwards if not enough space below
-        if ((rect.bottom + dropdownHeight + 4) > window.innerHeight && rect.top > dropdownHeight) {
-            top = rect.top - dropdownHeight - 4;
-        } else {
-            top = rect.bottom + 4;
-        }
-
-        let longestBranchWidth = 0;
-        if (branchLabelsForWidth.length > 0) {
-            const canvas = document.createElement('canvas');
-            const context = canvas.getContext('2d');
-            const computedStyle = window.getComputedStyle(buttonRef.current);
-            if (context) {
-                const font = computedStyle.font || `${computedStyle.fontSize || '14px'} ${computedStyle.fontFamily || 'sans-serif'}`;
-                context.font = font;
-                longestBranchWidth = branchLabelsForWidth.reduce((max, branchLabel) => {
-                    return Math.max(max, context.measureText(branchLabel).width);
-                }, 0);
-            } else {
-                longestBranchWidth = branchLabelsForWidth.reduce((max, branchLabel) => Math.max(max, branchLabel.length * 8), 0);
-            }
-        }
-
-        const triggerWidth = rect.width;
-        const horizontalPadding = 32; // Accounts for px-4 on both sides of menu items
-        const desiredWidth = Math.max(triggerWidth, longestBranchWidth + horizontalPadding);
-        const maxWidth = window.innerWidth - 10;
-        const minWidth = 200;
-        const width = Math.min(Math.max(desiredWidth, minWidth), maxWidth);
-
-        let left = rect.right - width;
-        if (left < 5) left = 5;
-        if (left + width > window.innerWidth - 5) left = window.innerWidth - width - 5;
-
-        setDropdownStyle({
-            position: 'fixed',
-            top: `${top}px`,
-            left: `${left}px`,
-            width: `${width}px`,
-        });
-    }, [branchLabelsForWidth, isOpen]);
-
     useEffect(() => {
         if (isOpen) {
             computeDropdownMetrics();
@@ -185,6 +135,56 @@ const BranchSwitcher: React.FC<{
     const branchLabelsForWidth = useMemo(() => {
         return [...otherLocalBranches, ...remoteBranchesToOffer];
     }, [otherLocalBranches, remoteBranchesToOffer]);
+
+    const computeDropdownMetrics = useCallback(() => {
+        if (!isOpen || !buttonRef.current) return;
+
+        const rect = buttonRef.current.getBoundingClientRect();
+        const dropdownHeight = 240; // Estimated height for max-h-60
+
+        let top: number;
+
+        // Position vertically: open upwards if not enough space below
+        if ((rect.bottom + dropdownHeight + 4) > window.innerHeight && rect.top > dropdownHeight) {
+            top = rect.top - dropdownHeight - 4;
+        } else {
+            top = rect.bottom + 4;
+        }
+
+        let longestBranchWidth = 0;
+        if (branchLabelsForWidth.length > 0) {
+            const canvas = document.createElement('canvas');
+            const context = canvas.getContext('2d');
+            const computedStyle = window.getComputedStyle(buttonRef.current);
+            if (context) {
+                const font = computedStyle.font || `${computedStyle.fontSize || '14px'} ${computedStyle.fontFamily || 'sans-serif'}`;
+                context.font = font;
+                longestBranchWidth = branchLabelsForWidth.reduce((max, branchLabel) => {
+                    return Math.max(max, context.measureText(branchLabel).width);
+                }, 0);
+            } else {
+                longestBranchWidth = branchLabelsForWidth.reduce((max, branchLabel) => Math.max(max, branchLabel.length * 8), 0);
+            }
+        }
+
+        const triggerWidth = rect.width;
+        const horizontalPadding = 32; // Accounts for px-4 on both sides of menu items
+        const desiredWidth = Math.max(triggerWidth, longestBranchWidth + horizontalPadding);
+        const maxWidth = window.innerWidth - 10;
+        const minWidth = 200;
+        const width = Math.min(Math.max(desiredWidth, minWidth), maxWidth);
+
+        let left = rect.right - width;
+        if (left < 5) left = 5;
+        if (left + width > window.innerWidth - 5) left = window.innerWidth - width - 5;
+
+        setDropdownStyle({
+            position: 'fixed',
+            top: `${top}px`,
+            left: `${left}px`,
+            width: `${width}px`,
+        });
+    }, [branchLabelsForWidth, isOpen]);
 
     const mainBranch = useMemo(() => {
         if (local.includes('main')) {

--- a/contexts/SettingsContext.tsx
+++ b/contexts/SettingsContext.tsx
@@ -3,7 +3,6 @@ import React, { createContext, useState, useCallback, ReactNode, useMemo, useEff
 import type { GlobalSettings, Repository, Category, DropTarget } from '../types';
 import { RepoStatus, BuildHealth, VcsType, TaskStepType } from '../types';
 import { MIN_AUTO_CHECK_INTERVAL_SECONDS, MAX_AUTO_CHECK_INTERVAL_SECONDS } from '../constants';
-import { useLogger } from '../hooks/useLogger';
 import { createDefaultKeyboardShortcutSettings, mergeKeyboardShortcutSettings } from '../keyboardShortcuts';
 
 interface AppDataContextState {
@@ -324,7 +323,6 @@ const categoryReducer = (state: CategoryState, action: CategoryAction): Category
 };
 
 export const SettingsProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const logger = useLogger();
   const [settings, setSettings] = useState<GlobalSettings>(DEFAULTS);
   const [repositories, setRepositories] = useState<Repository[]>([]);
   
@@ -439,9 +437,11 @@ export const SettingsProvider: React.FC<{ children: ReactNode }> = ({ children }
 
   // FIX: Refactor moveRepositoryToCategory to dispatch an action to the central reducer.
   const moveRepositoryToCategory = useCallback((repoId: string, sourceId: string | 'uncategorized', target: DropTarget) => {
-    logger.debug(`[DnD] Dispatching MOVE_REPOSITORY_DND`, { repoId, sourceId, target });
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug('[DnD] Dispatching MOVE_REPOSITORY_DND', { repoId, sourceId, target });
+    }
     dispatch({ type: 'MOVE_REPOSITORY_DND', payload: { repoId, sourceId, target } });
-  }, [logger]);
+  }, []);
 
   const moveRepository = useCallback((repoId: string, direction: 'up' | 'down') => {
     dispatch({ type: 'MOVE_REPOSITORY_BUTTONS', payload: { repoId, direction } });


### PR DESCRIPTION
## Summary
- define branch label memoization before computing dropdown metrics in RepositoryCard
- ensure the branch dropdown metrics callback no longer runs before its dependencies initialize, preventing the renderer crash

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ded2ec99288332a7e26c71d4f6bbfc