### PR TITLE
Improve renderer crash diagnostics

### DIFF
--- a/components/AppErrorBoundary.tsx
+++ b/components/AppErrorBoundary.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { LoggerContext } from '../contexts/LoggerContext';
+import { DebugLogLevel } from '../types';
+
+interface AppErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+interface AppErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: React.ErrorInfo | null;
+  componentTrace: string[];
+}
+
+export class AppErrorBoundary extends React.Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  static contextType = LoggerContext;
+  declare context: React.ContextType<typeof LoggerContext>;
+
+  state: AppErrorBoundaryState = {
+    hasError: false,
+    error: null,
+    errorInfo: null,
+    componentTrace: [],
+  };
+
+  static getDerivedStateFromError(error: Error): AppErrorBoundaryState {
+    return { hasError: true, error, errorInfo: null, componentTrace: [] };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    const componentTrace = this.extractComponentTrace(errorInfo.componentStack);
+
+    console.group('[AppErrorBoundary] Caught unhandled error');
+    console.error('Error', error);
+    if (error.stack) {
+      console.error('Stack trace', error.stack);
+    }
+    if (componentTrace.length > 0) {
+      console.error('Component trace', componentTrace);
+    } else if (errorInfo.componentStack) {
+      console.error('Raw component stack', errorInfo.componentStack);
+    }
+    console.groupEnd();
+
+    try {
+      const logger = this.context;
+      if (logger && typeof logger.addLog === 'function') {
+        logger.addLog(DebugLogLevel.ERROR, `Unhandled renderer error: ${error.message}`, {
+          stack: error.stack,
+          componentStack: errorInfo.componentStack,
+          componentTrace,
+        });
+      }
+    } catch (loggingError) {
+      console.error('[AppErrorBoundary] Failed to forward error to LoggerContext', loggingError);
+    }
+
+    this.setState({ errorInfo, componentTrace });
+  }
+
+  private extractComponentTrace(componentStack?: string | null): string[] {
+    if (!componentStack) {
+      return [];
+    }
+
+    return componentStack
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .map(line => line.replace(/^in\s+/, '').replace(/\s+\(.+\)$/, ''))
+      .filter(Boolean);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null, errorInfo: null, componentTrace: [] });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-4 bg-red-900/10 p-8 text-center">
+          <h1 className="text-2xl font-semibold text-red-600 dark:text-red-400">Something went wrong</h1>
+          <p className="max-w-xl text-sm text-gray-700 dark:text-gray-200">
+            The renderer crashed before it could finish loading. Check the developer console for the full stack trace.
+            A copy of the error message and component stack has been forwarded to the in-app debug log.
+          </p>
+          {this.state.error && (
+            <pre className="max-w-xl overflow-auto rounded bg-black/60 p-3 text-left text-xs text-red-200">
+              {this.state.error.message}
+              {this.state.error.stack ? `\n\n${this.state.error.stack}` : ''}
+              {this.state.errorInfo?.componentStack ? `\n\nComponent stack:${this.state.errorInfo.componentStack}` : ''}
+            </pre>
+          )}
+          {this.state.componentTrace.length > 0 && (
+            <div className="max-w-xl space-y-2 rounded border border-red-500/40 bg-black/40 p-3 text-left text-xs text-red-100">
+              <div className="font-semibold uppercase tracking-wide text-red-300">Component trace</div>
+              <ol className="list-inside list-decimal space-y-1">
+                {this.state.componentTrace.map((name, index) => (
+                  <li key={`${name}-${index}`}>{name}</li>
+                ))}
+              </ol>
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400"
+          >
+            Retry loading
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/components/RepositoryCard.tsx
+++ b/components/RepositoryCard.tsx
@@ -84,56 +84,6 @@ const BranchSwitcher: React.FC<{
     const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
     const [isModalOpen, setIsModalOpen] = useState(false);
     
-    const computeDropdownMetrics = useCallback(() => {
-        if (!isOpen || !buttonRef.current) return;
-
-        const rect = buttonRef.current.getBoundingClientRect();
-        const dropdownHeight = 240; // Estimated height for max-h-60
-
-        let top: number;
-
-        // Position vertically: open upwards if not enough space below
-        if ((rect.bottom + dropdownHeight + 4) > window.innerHeight && rect.top > dropdownHeight) {
-            top = rect.top - dropdownHeight - 4;
-        } else {
-            top = rect.bottom + 4;
-        }
-
-        let longestBranchWidth = 0;
-        if (branchLabelsForWidth.length > 0) {
-            const canvas = document.createElement('canvas');
-            const context = canvas.getContext('2d');
-            const computedStyle = window.getComputedStyle(buttonRef.current);
-            if (context) {
-                const font = computedStyle.font || `${computedStyle.fontSize || '14px'} ${computedStyle.fontFamily || 'sans-serif'}`;
-                context.font = font;
-                longestBranchWidth = branchLabelsForWidth.reduce((max, branchLabel) => {
-                    return Math.max(max, context.measureText(branchLabel).width);
-                }, 0);
-            } else {
-                longestBranchWidth = branchLabelsForWidth.reduce((max, branchLabel) => Math.max(max, branchLabel.length * 8), 0);
-            }
-        }
-
-        const triggerWidth = rect.width;
-        const horizontalPadding = 32; // Accounts for px-4 on both sides of menu items
-        const desiredWidth = Math.max(triggerWidth, longestBranchWidth + horizontalPadding);
-        const maxWidth = window.innerWidth - 10;
-        const minWidth = 200;
-        const width = Math.min(Math.max(desiredWidth, minWidth), maxWidth);
-
-        let left = rect.right - width;
-        if (left < 5) left = 5;
-        if (left + width > window.innerWidth - 5) left = window.innerWidth - width - 5;
-
-        setDropdownStyle({
-            position: 'fixed',
-            top: `${top}px`,
-            left: `${left}px`,
-            width: `${width}px`,
-        });
-    }, [branchLabelsForWidth, isOpen]);
-
     useEffect(() => {
         if (isOpen) {
             computeDropdownMetrics();
@@ -185,6 +135,56 @@ const BranchSwitcher: React.FC<{
     const branchLabelsForWidth = useMemo(() => {
         return [...otherLocalBranches, ...remoteBranchesToOffer];
     }, [otherLocalBranches, remoteBranchesToOffer]);
+
+    const computeDropdownMetrics = useCallback(() => {
+        if (!isOpen || !buttonRef.current) return;
+
+        const rect = buttonRef.current.getBoundingClientRect();
+        const dropdownHeight = 240; // Estimated height for max-h-60
+
+        let top: number;
+
+        // Position vertically: open upwards if not enough space below
+        if ((rect.bottom + dropdownHeight + 4) > window.innerHeight && rect.top > dropdownHeight) {
+            top = rect.top - dropdownHeight - 4;
+        } else {
+            top = rect.bottom + 4;
+        }
+
+        let longestBranchWidth = 0;
+        if (branchLabelsForWidth.length > 0) {
+            const canvas = document.createElement('canvas');
+            const context = canvas.getContext('2d');
+            const computedStyle = window.getComputedStyle(buttonRef.current);
+            if (context) {
+                const font = computedStyle.font || `${computedStyle.fontSize || '14px'} ${computedStyle.fontFamily || 'sans-serif'}`;
+                context.font = font;
+                longestBranchWidth = branchLabelsForWidth.reduce((max, branchLabel) => {
+                    return Math.max(max, context.measureText(branchLabel).width);
+                }, 0);
+            } else {
+                longestBranchWidth = branchLabelsForWidth.reduce((max, branchLabel) => Math.max(max, branchLabel.length * 8), 0);
+            }
+        }
+
+        const triggerWidth = rect.width;
+        const horizontalPadding = 32; // Accounts for px-4 on both sides of menu items
+        const desiredWidth = Math.max(triggerWidth, longestBranchWidth + horizontalPadding);
+        const maxWidth = window.innerWidth - 10;
+        const minWidth = 200;
+        const width = Math.min(Math.max(desiredWidth, minWidth), maxWidth);
+
+        let left = rect.right - width;
+        if (left < 5) left = 5;
+        if (left + width > window.innerWidth - 5) left = window.innerWidth - width - 5;
+
+        setDropdownStyle({
+            position: 'fixed',
+            top: `${top}px`,
+            left: `${left}px`,
+            width: `${width}px`,
+        });
+    }, [branchLabelsForWidth, isOpen]);
 
     const mainBranch = useMemo(() => {
         if (local.includes('main')) {

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -24,6 +24,7 @@ const rendererConfig = {
     format: 'iife',
     sourcemap: !isProd,
     minify: isProd,
+    keepNames: true,
     define: {
         'process.env.NODE_ENV': JSON.stringify(isProd ? 'production' : 'development'),
         // API_KEY needs to be available in the renderer process

--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,47 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { LoggerProvider } from './contexts/LoggerContext';
 import { SettingsProvider } from './contexts/SettingsContext';
+import { AppErrorBoundary } from './components/AppErrorBoundary';
+
+declare global {
+  interface Window {
+    __appDiagnosticsRegistered__?: boolean;
+  }
+}
+
+const registerGlobalDiagnostics = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (window.__appDiagnosticsRegistered__) {
+    return;
+  }
+
+  window.__appDiagnosticsRegistered__ = true;
+
+  console.info('[RendererBootstrap] Registering global diagnostics handlers');
+
+  window.addEventListener('error', event => {
+    console.error('[RendererBootstrap] Unhandled error event', {
+      message: event.message,
+      filename: event.filename,
+      lineno: event.lineno,
+      colno: event.colno,
+      error: event.error,
+    });
+  });
+
+  window.addEventListener('unhandledrejection', event => {
+    console.error('[RendererBootstrap] Unhandled promise rejection', {
+      reason: event.reason,
+    });
+  });
+};
+
+registerGlobalDiagnostics();
+
+console.info('[RendererBootstrap] Starting application render');
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -14,7 +55,9 @@ root.render(
   <React.StrictMode>
     <SettingsProvider>
       <LoggerProvider>
-        <App />
+        <AppErrorBoundary>
+          <App />
+        </AppErrorBoundary>
       </LoggerProvider>
     </SettingsProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- enhance the renderer error boundary to capture and display a formatted component trace alongside the raw stack information
- log richer diagnostics when crashes occur so the debug log and console contain structured context
- preserve component and function names in production bundles to keep stack traces readable during investigations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ded2ec99288332a7e26c71d4f6bbfc