### PR TITLE
Update restore window icon to match Windows style

### DIFF
--- a/components/icons/RestoreIcon.tsx
+++ b/components/icons/RestoreIcon.tsx
@@ -1,9 +1,30 @@
 import React from 'react';
 
 const RestoreIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
- <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" {...props}>
-  <path strokeLinecap="round" strokeLinejoin="round" d="M16.5 8.25V6a2.25 2.25 0 00-2.25-2.25H6A2.25 2.25 0 003.75 6v8.25A2.25 2.25 0 006 16.5h2.25m8.25-8.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-8.25A2.25 2.25 0 017.5 18v-2.25m8.25-8.25l-6 6" />
-</svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={2}
+    stroke="currentColor"
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.75 8.25h6a1.5 1.5 0 011.5 1.5v6a1.5 1.5 0 01-1.5 1.5h-6a1.5 1.5 0 01-1.5-1.5v-6a1.5 1.5 0 011.5-1.5z"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15.75 8.25V6a1.5 1.5 0 00-1.5-1.5h-6A1.5 1.5 0 006.75 6v2.25"
+    />
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M8.25 15.75H6a1.5 1.5 0 01-1.5-1.5v-6A1.5 1.5 0 016 6.75h2.25"
+    />
+  </svg>
 );
 
 export { RestoreIcon };


### PR DESCRIPTION
## Summary
- restyle the custom restore button icon to depict overlapping windows similar to native controls

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68dfe58603408332b2450db6aeec6280