### PR TITLE
chore: prepare 0.24.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 - _No unreleased changes._
 
+## [0.24.6]
+
+### Changed
+- **Documentation Checklist Clarity:** Clarified the release preparation steps in `README.md` and `TECHNICAL_MANUAL.md` so
+  maintainers explicitly record the outcome of their documentation review (even when no edits are required) before publishing a
+  release.
+
+### Fixed
+- **Version Metadata:** Incremented the application version to `0.24.6` in `package.json` ahead of publishing this patch build.
+
 ## [0.24.5]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Follow this checklist when preparing a new minor or patch release:
 1.  **Bump the Version:** Update the `version` field in `package.json` and ensure any user-facing references (README, manuals,
     in-app messaging) match the new number.
 2.  **Review Documentation:** Re-read the README, Functional Manual, Technical Manual, and CHANGELOG to confirm terminology and
-    screenshots reflect the current UI and workflow. Capture any documentation-only tweaks in the upcoming changelog entry so the
-    review is recorded.
+    screenshots reflect the current UI and workflow. Capture any documentation-only tweaks in the upcoming changelog entry, and
+    if everything is still accurate, explicitly state that outcome so the review itself is recorded.
 3.  **Update Release Notes:** Add a new section to `CHANGELOG.md` summarizing the changes included in the release, including
     any documentation adjustments or reminders for maintainers. Plan to reuse this text verbatim in the GitHub release body.
 4.  **Run Automated Checks:** Execute `npm test` (or the appropriate suite documented in the Technical Manual) and confirm it completes successfully before packaging.

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -90,7 +90,7 @@ All application data, including repositories, categories, and global settings, i
 Use this process when shipping a new minor update or bugfix:
 
 1.  **Increment the Version:** Update the `version` in `package.json` and verify the README, manuals, and any in-app references reflect the new number where applicable.
-2.  **Refresh Documentation:** Re-read `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `CHANGELOG.md` to ensure screenshots, feature descriptions, and workflows match the current UI. Note any documentation-only edits in the changelog so the audit trail is preserved.
+2.  **Refresh Documentation:** Re-read `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `CHANGELOG.md` to ensure screenshots, feature descriptions, and workflows match the current UI. Note any documentation-only edits in the changelog, and if no changes are required, explicitly record that the review confirmed the docs remain accurate so the audit trail is preserved.
 3.  **Update Release Notes:** Add a new entry to `CHANGELOG.md` summarizing the changes, calling out documentation adjustments alongside any fixes or features. Plan to reuse this text verbatim in the GitHub release body.
 4.  **Run Automated Checks:** Execute `npm test` (or the broader QA suite defined for the project) and confirm a passing result before packaging binaries.
 5.  **Build Installers:** Run `npm run pack`. The command produces platform installers in the `release/` directory. Perform a quick smoke test of the generated artifacts before distribution.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-automation-dashboard",
-  "version": "0.24.5",
+  "version": "0.24.6",
   "description": "A dashboard to manage and automate the workflow for a set of Git repositories.",
   "main": "dist/main.js",
   "author": "AI Assistant",


### PR DESCRIPTION
## Summary
- bump the application version to 0.24.6 in preparation for the next patch release
- add a 0.24.6 changelog entry that records the version bump and documentation review
- clarify the README and Technical Manual release checklists to document doc-review outcomes even when no edits are needed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dff5d241b88332b920383f4a3f342a