### PR TITLE
Prepare v0.24.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 - _No unreleased changes._
 
+## [0.24.7]
+
+### Changed
+- **Documentation Review:** Reconfirmed that `README.md`, `TECHNICAL_MANUAL.md`, and `FUNCTIONAL_MANUAL.md` accurately describe the
+  current release workflow and UI, so no content edits were required before publishing this build.
+
+### Fixed
+- **Version Metadata:** Incremented the application version to `0.24.7` in `package.json` to prepare this bugfix release.
+
 ## [0.24.6]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-automation-dashboard",
-  "version": "0.24.6",
+  "version": "0.24.7",
   "description": "A dashboard to manage and automate the workflow for a set of Git repositories.",
   "main": "dist/main.js",
   "author": "AI Assistant",


### PR DESCRIPTION
## Summary
- bump the application version to 0.24.7 for the upcoming bugfix release
- document the documentation review outcome and version increment in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e00a06cc4c833299996b4492e5c81c