### PR TITLE
Improve branch selection dialog with commit metadata

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1936,11 +1936,11 @@ ipcMain.handle('list-branches', async (event, repoPath: string): Promise<BranchI
             '%(objectname:short)',
             '%(subject)',
         ];
-        const format = `--format=${formatSegments.join('%00')}`;
+        const format = formatSegments.join('%00');
         const gitExecutable = getExecutableCommand(VcsTypeEnum.Git, settings, false);
         const { stdout } = await execFileAsync(
             gitExecutable,
-            ['for-each-ref', '--sort=-committerdate', format, 'refs/heads', 'refs/remotes'],
+            ['for-each-ref', '--sort=-committerdate', '--format', format, 'refs/heads', 'refs/remotes'],
             { cwd: repoPath },
         );
         const branches: BranchInfo = { local: [], remote: [], current, details: {} };
@@ -1955,9 +1955,10 @@ ipcMain.handle('list-branches', async (event, repoPath: string): Promise<BranchI
                 if (segments.length < 7) {
                     return;
                 }
-                const [refName, shortName, isoDate, relativeDate, authorName, shortHash, subject] = segments.map(segment =>
+                const [rawRefName, shortName, isoDate, relativeDate, authorName, shortHash, subject] = segments.map(segment =>
                     segment.trim(),
                 );
+                const refName = rawRefName.replace(/^'+|'+$/g, '');
                 const isRemote = refName.startsWith('refs/remotes/');
                 const isLocal = refName.startsWith('refs/heads/');
                 if (!isRemote && !isLocal) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1927,10 +1927,20 @@ ipcMain.handle('list-branches', async (event, repoPath: string): Promise<BranchI
             current = null;
         }
 
-        const format =
-            '%(refname)%00%(refname:short)%00%(committerdate:iso8601)%00%(committerdate:relative)%00%(authorname)%00%(objectname:short)%00%(subject)';
-        const { stdout } = await execAsync(
-            `${gitCmd} for-each-ref --sort=-committerdate --format='${format}' refs/heads refs/remotes`,
+        const formatSegments = [
+            '%(refname)',
+            '%(refname:short)',
+            '%(committerdate:iso8601)',
+            '%(committerdate:relative)',
+            '%(authorname)',
+            '%(objectname:short)',
+            '%(subject)',
+        ];
+        const format = `--format=${formatSegments.join('%00')}`;
+        const gitExecutable = getExecutableCommand(VcsTypeEnum.Git, settings, false);
+        const { stdout } = await execFileAsync(
+            gitExecutable,
+            ['for-each-ref', '--sort=-committerdate', format, 'refs/heads', 'refs/remotes'],
             { cwd: repoPath },
         );
         const branches: BranchInfo = { local: [], remote: [], current, details: {} };

--- a/types.ts
+++ b/types.ts
@@ -300,10 +300,21 @@ export interface DetailedStatus {
   updatesAvailable?: boolean; // SVN only
 }
 
+export interface BranchMetadata {
+  name: string;
+  type: 'local' | 'remote';
+  lastCommitDate: string | null;
+  lastCommitRelative: string | null;
+  lastCommitAuthor: string | null;
+  lastCommitMessage: string | null;
+  lastCommitSha: string | null;
+}
+
 export interface BranchInfo {
   local: string[];
   remote: string[];
   current: string | null;
+  details: Record<string, BranchMetadata>;
 }
 
 export type UpdateStatus = 'checking' | 'available' | 'downloaded' | 'error';


### PR DESCRIPTION
## Summary
- sort branch entries by their latest commit time so the most recent branches appear first
- surface commit author, age, message, and hash in the branch switch dialog for better context
- extend branch metadata returned from the backend to include detailed commit information for each branch

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0e62831088332899cfa91bf706949