### PR TITLE
Add Go, Rust, Maven, and .NET project intelligence support

### DIFF
--- a/FUNCTIONAL_MANUAL.md
+++ b/FUNCTIONAL_MANUAL.md
@@ -106,10 +106,10 @@ This is the main panel where you configure the name, path, URL, and launch confi
 
 #### Tasks Tab
 This is where you create powerful, custom automation scripts for the specific repository you are editing.
-1.  **Project Intelligence:** Based on the repository's local path, the application will analyze its contents to detect the project type (e.g., Node.js, Python, Delphi, Docker). If a known type is found, a colored box will appear with buttons to automatically generate common tasks for that ecosystem.
+1.  **Project Intelligence:** Based on the repository's local path, the application will analyze its contents to detect the project type (e.g., Node.js, Python, Go, Rust, Maven/Java, .NET, Delphi, Docker). If a known type is found, a colored box will appear with buttons to automatically generate common tasks for that ecosystem—including language-aware defaults like `go mod download`, `cargo test`, `mvn clean install`, and `dotnet restore`.
 2.  **Manual Task Creation:**
     -   Give your task a descriptive **name** (e.g., "Build & Deploy to Staging").
-    -   Click **"Add Step"** to build your workflow. A new panel will appear, grouping available steps into logical categories like 'Git', 'Node.js', and 'Python', making it easy to find the action you need. The available steps will depend on the repository's VCS type and its detected project type.
+    -   Click **"Add Step"** to build your workflow. A new panel will appear, grouping available steps into logical categories like 'Git', 'Node.js', 'Go', 'Rust', 'Maven', '.NET', and 'Python', making it easy to find the action you need. The available steps will depend on the repository's VCS type and its detected project type.
     -   Configure each step as needed.
 3.  **Variables:**
     -   **Task Variables:** These are for simple text substitution. Define a `KEY` and `VALUE`, then use `${KEY}` in a `Run Command` step's command field.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This application provides a simple, powerful dashboard to manage and automate th
 -   **Customizable Dashboard Categories:** Organize your repositories into collapsible sections with **dual-theme (light/dark) color styling**, a library of predefined themes, full drag-and-drop support (for both repositories and categories), and alternative up/down reorder buttons.
 -   **Multi-VCS Support:** Manage both Git and Subversion (SVN) repositories seamlessly.
 -   **Repository-Specific Tasks:** Create custom, multi-step automation scripts (e.g., pull/update, install, build) for each repository.
--   **Project Intelligence:** Automatically detects project types (Node.js, Python, Delphi, Lazarus, Docker) and provides one-click buttons to generate common, pre-configured tasks.
--   **Advanced Task Steps:** A rich library of specific, pre-built steps for different ecosystems, **now organized into logical categories in the UI for easy discovery**, simplifies creating complex workflows.
+-   **Project Intelligence:** Automatically detects project types (Node.js, Python, Go, Rust, Maven/Java, .NET, Delphi, Lazarus, Docker) and provides one-click buttons to generate common, pre-configured tasks for each ecosystem.
+-   **Advanced Task Steps:** A rich library of specific, pre-built steps for different ecosystems, **now organized into logical categories in the UI for easy discovery**, simplifies creating complex workflows. The catalog now includes dedicated actions for Go toolchains, Cargo-powered Rust projects, Maven builds, and dotnet CLI operations alongside the existing language families.
 -   **Task Environment Variables:** Define shell environment variables that are available to all command steps within a task.
 -   **Quick Actions:** Manually refresh repository state, copy URLs/paths with a single click, access all common actions via a right-click context menu, and reorder repositories with up/down buttons.
 -   **Powerful Command Palette:** Quickly access any action, task, or repository using the keyboard shortcut (`Ctrl/Cmd+K`) to open a powerful search-driven command modal.

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -32,8 +32,8 @@ The application uses a custom frameless window to achieve a modern, VSCode-like 
     -   Reads user settings on startup to configure features like the auto-updater's pre-release channel.
     -   Handles native OS interactions (dialogs, file system access).
     -   Listens for and responds to IPC (Inter-Process Communication) events. This includes:
-        -   **Project Intelligence:** Handles `get-project-info` and `get-project-suggestions` by analyzing the file system of a repository to detect technologies like Node.js, Python, Delphi, and Lazarus.
-        -   **Task Execution:** Executes shell commands for task steps. The `run-task-step` handler now contains logic to interpret and execute the new, ecosystem-specific step types (e.g., `PYTHON_INSTALL_DEPS`). It also handles setting environment variables for tasks.
+        -   **Project Intelligence:** Handles `get-project-info` and `get-project-suggestions` by analyzing the file system of a repository to detect technologies like Node.js, Python, Go, Rust, Maven/Java, .NET, Delphi, Lazarus, and Docker.
+        -   **Task Execution:** Executes shell commands for task steps. The `run-task-step` handler now contains logic to interpret and execute the ecosystem-specific step types (e.g., `PYTHON_INSTALL_DEPS`, `GO_MOD_DOWNLOAD`, `RUST_CARGO_TEST`, `MAVEN_CLEAN_INSTALL`, `DOTNET_BUILD`). It also handles setting environment variables for tasks.
         -   **Task Log Archiving:** Upon starting a task, it creates a timestamped log file in the user-configured directory. It then streams all `stdout` and `stderr` from the task's execution to this file, in addition to the live view in the UI.
         -   **VCS Commands:** Executes real Git/SVN commands for advanced features like checking status, fetching commit history (now for SVN as well), and managing branches.
         -   **Executable Path Management:** Handles IPC calls for file pickers, auto-detection, and testing of user-configured executable paths.

--- a/types.ts
+++ b/types.ts
@@ -102,6 +102,27 @@ export enum TaskStepType {
   NODE_RUN_TYPECHECK = 'NODE_RUN_TYPECHECK',
   NODE_RUN_TESTS = 'NODE_RUN_TESTS',
   NODE_RUN_BUILD = 'NODE_RUN_BUILD',
+  // Go
+  GO_MOD_DOWNLOAD = 'GO_MOD_DOWNLOAD',
+  GO_TEST = 'GO_TEST',
+  GO_BUILD = 'GO_BUILD',
+  GO_FMT = 'GO_FMT',
+  GO_LINT = 'GO_LINT',
+  // Rust
+  RUST_CARGO_FETCH = 'RUST_CARGO_FETCH',
+  RUST_CARGO_BUILD = 'RUST_CARGO_BUILD',
+  RUST_CARGO_TEST = 'RUST_CARGO_TEST',
+  RUST_CARGO_FMT = 'RUST_CARGO_FMT',
+  RUST_CARGO_CLIPPY = 'RUST_CARGO_CLIPPY',
+  // Maven
+  MAVEN_CLEAN_INSTALL = 'MAVEN_CLEAN_INSTALL',
+  MAVEN_TEST = 'MAVEN_TEST',
+  MAVEN_PACKAGE = 'MAVEN_PACKAGE',
+  // .NET
+  DOTNET_RESTORE = 'DOTNET_RESTORE',
+  DOTNET_BUILD = 'DOTNET_BUILD',
+  DOTNET_TEST = 'DOTNET_TEST',
+  DOTNET_PUBLISH = 'DOTNET_PUBLISH',
   // Lazarus/FPC
   LAZARUS_BUILD = 'LAZARUS_BUILD',
   LAZARUS_BUILD_PACKAGE = 'LAZARUS_BUILD_PACKAGE',
@@ -412,6 +433,56 @@ export interface NodejsCapabilities {
   monorepo: { workspaces: boolean, turbo: boolean, nx: boolean, yarnBerryPnp: boolean };
 }
 
+export interface GoModuleInfo {
+  path: string;
+  module: string | null;
+}
+
+export interface GoCapabilities {
+  modules: GoModuleInfo[];
+  hasGoWork: boolean;
+  hasGoSum: boolean;
+  lintTools: ('golangci-lint')[];
+  formatters: ('gofmt')[];
+  hasTests: boolean;
+}
+
+export interface RustManifestInfo {
+  path: string;
+  name: string | null;
+  edition: string | null;
+  isWorkspaceRoot: boolean;
+}
+
+export interface RustCapabilities {
+  manifests: RustManifestInfo[];
+  hasLockfile: boolean;
+  hasClippyConfig: boolean;
+  hasFmtConfig: boolean;
+}
+
+export interface MavenModuleInfo {
+  path: string;
+  artifactId: string | null;
+  packaging: string | null;
+}
+
+export interface MavenCapabilities {
+  modules: MavenModuleInfo[];
+  usesWrapper: boolean;
+}
+
+export interface DotnetProjectInfo {
+  path: string;
+  targetFrameworks: string[];
+  isTestProject: boolean;
+}
+
+export interface DotnetCapabilities {
+  projects: DotnetProjectInfo[];
+  solutions: string[];
+}
+
 export interface ProjectInfo {
   tags: string[];
   files: { dproj: string[] };
@@ -420,4 +491,8 @@ export interface ProjectInfo {
   nodejs?: NodejsCapabilities;
   lazarus?: LazarusCapabilities;
   docker?: DockerCapabilities;
+  go?: GoCapabilities;
+  rust?: RustCapabilities;
+  maven?: MavenCapabilities;
+  dotnet?: DotnetCapabilities;
 }


### PR DESCRIPTION
## Summary
- extend project analysis to detect Go, Rust, Maven, and .NET repositories and capture capability metadata for automation
- introduce ecosystem-specific task step types, execution handlers, and UI generators for Go, Rust, Maven, and .NET workflows
- refresh end-user documentation to highlight the expanded language support and default automation templates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11d1811d48332b17d2b59150d0fd8