### PR TITLE
Prepare release 0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 - _No unreleased changes._
 
+## [0.25.1]
+
+### Changed
+- **Documentation Audit Trail:** Reconfirmed that `README.md`, `TECHNICAL_MANUAL.md`, `FUNCTIONAL_MANUAL.md`, and `docs/keyboard-shortcut-editor.md` remain accurate for version `0.25.1`, recording the review outcome for this release.
+
+### Fixed
+- **Version Metadata:** Incremented the application version to `0.25.1` in `package.json` to prepare this patch release.
+
 ## [0.25.0]
 
 ### Changed

--- a/FUNCTIONAL_MANUAL.md
+++ b/FUNCTIONAL_MANUAL.md
@@ -183,6 +183,6 @@ For advanced users, the settings view includes a **"JSON Config"** tab. This sec
 -   **Export Settings:** Click the "Export Settings" button to save your current configuration into a compressed `.zip` archive. This is useful for creating backups or sharing your setup.
 -   **Import Settings:** Click the "Import Settings" button. You can select a `.zip` archive (created via the export feature) or a raw `.json` file to restore a configuration. This will overwrite your current settings and restart the application.
 
-### Documentation Status for 0.25.0
+### Documentation Status for 0.25.1
 
-- Conducted a full functional review of the UI flows described in this manual, the README, the Technical Manual, and the keyboard shortcut specification. Everything continues to match the live application for version `0.25.0`, so no functional wording changes were needed beyond documenting this verification.
+- Conducted a full functional review of the UI flows described in this manual, the README, the Technical Manual, and the keyboard shortcut specification. Everything continues to match the live application for version `0.25.1`, so no functional wording changes were needed beyond documenting this verification.

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Follow this checklist when preparing a new minor or patch release:
     **Release Type** selector to the intended state (Full Release for GA builds, Draft or Pre-release as needed). Paste the freshly
     written changelog entry into the release body so the GitHub notes exactly match the repository history, then publish.
 
-### Documentation Status for 0.25.0
+### Documentation Status for 0.25.1
 
-- Re-reviewed `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `docs/keyboard-shortcut-editor.md` for this release.
-  No workflow or UI updates were required; this note records that the audit confirmed the documentation remains accurate for version
-  `0.25.0`.
+- Re-ran the documentation audit across `README.md`, `FUNCTIONAL_MANUAL.md`, `TECHNICAL_MANUAL.md`, and `docs/keyboard-shortcut-editor.md` for this release.
+  No workflow or UI updates were required; this note records that the review confirmed the guidance remains accurate for version
+  `0.25.1`.
 
 ---
 _For developer information, including how to run this project in development mode or build it from source, please see the **Technical Manual** tab in the Info Hub._

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -96,9 +96,9 @@ Use this process when shipping a new minor update or bugfix:
 5.  **Build Installers:** Run `npm run pack`. The command produces platform installers in the `release/` directory. Perform a quick smoke test of the generated artifacts before distribution.
 6.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, verify the tag/version details, and explicitly set the **Release Type** selector to match your intent (Full Release for GA builds or Draft/Pre-release when staging). Paste the current changelog entry into the notes so the GitHub release matches the repository history, then publish.
 
-### Documentation Status for 0.25.0
+### Documentation Status for 0.25.1
 
-- Confirmed that all technical guidance in this manual, the Functional Manual, the README, and the keyboard shortcut specification still aligns with the current codebase and UI for version `0.25.0`; no content corrections were necessary beyond this recorded audit.
+- Reconfirmed that all technical guidance in this manual, the Functional Manual, the README, and the keyboard shortcut specification still aligns with the current codebase and UI for version `0.25.1`; no content corrections were necessary beyond this recorded audit.
 ## 7. Automatic Updates
 
 The application is configured to automatically check for updates on startup using the `electron-updater` library.

--- a/docs/keyboard-shortcut-editor.md
+++ b/docs/keyboard-shortcut-editor.md
@@ -71,6 +71,6 @@ The catalog defines the canonical list of actions and their defaults.
 ## Future Hooks
 - The structure supports hooking into a runtime shortcut registry (e.g., via a dedicated context) by indexing `settings.keyboardShortcuts.bindings`. Any consumer can reuse `shortcutKey` and the catalog to register listeners or show active shortcut hints. The state object is already versioned (`version: 1`) to accommodate future schema migrations.【F:keyboardShortcuts.ts†L285-L313】【F:types.ts†L23-L49】
 
-## Documentation Status for 0.25.0
-- Validated that the shortcut editor architecture, UI flows, and persistence notes above still reflect the current implementation for version `0.25.0`. No technical adjustments were required beyond recording this confirmation for the release audit trail.
+## Documentation Status for 0.25.1
+- Re-validated that the shortcut editor architecture, UI flows, and persistence notes above still reflect the current implementation for version `0.25.1`. No technical adjustments were required beyond recording this confirmation for the release audit trail.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-automation-dashboard",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "A dashboard to manage and automate the workflow for a set of Git repositories.",
   "main": "dist/main.js",
   "author": "AI Assistant",


### PR DESCRIPTION
## Summary
- bump the application version to 0.25.1 for the upcoming patch release
- reaffirm documentation status across the README, manuals, and shortcut editor guide for this build
- add a changelog entry capturing the 0.25.1 review outcome and version update

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e11ff6cae08332b31651167776c3db