### PR TITLE
feat: extend project intelligence for Go, Rust, Maven, and .NET

### DIFF
--- a/FUNCTIONAL_MANUAL.md
+++ b/FUNCTIONAL_MANUAL.md
@@ -106,7 +106,7 @@ This is the main panel where you configure the name, path, URL, and launch confi
 
 #### Tasks Tab
 This is where you create powerful, custom automation scripts for the specific repository you are editing.
-1.  **Project Intelligence:** Based on the repository's local path, the application will analyze its contents to detect the project type (e.g., Node.js, Python, Delphi, Docker). If a known type is found, a colored box will appear with buttons to automatically generate common tasks for that ecosystem.
+1.  **Project Intelligence:** Based on the repository's local path, the application will analyze its contents to detect the project type (e.g., Node.js, Python, Go, Rust, Java/Maven, .NET, Delphi, Docker, Lazarus). If a known type is found, a colored box will appear with buttons to automatically generate common tasks for that ecosystem—such as Go mod tidy/CI pipelines, Cargo formatting and linting flows, Maven clean/test/package lifecycles, or .NET restore/build/test sequences—ready to drop into your task list.
 2.  **Manual Task Creation:**
     -   Give your task a descriptive **name** (e.g., "Build & Deploy to Staging").
     -   Click **"Add Step"** to build your workflow. A new panel will appear, grouping available steps into logical categories like 'Git', 'Node.js', and 'Python', making it easy to find the action you need. The available steps will depend on the repository's VCS type and its detected project type.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This application provides a simple, powerful dashboard to manage and automate th
 -   **Customizable Dashboard Categories:** Organize your repositories into collapsible sections with **dual-theme (light/dark) color styling**, a library of predefined themes, full drag-and-drop support (for both repositories and categories), and alternative up/down reorder buttons.
 -   **Multi-VCS Support:** Manage both Git and Subversion (SVN) repositories seamlessly.
 -   **Repository-Specific Tasks:** Create custom, multi-step automation scripts (e.g., pull/update, install, build) for each repository.
--   **Project Intelligence:** Automatically detects project types (Node.js, Python, Delphi, Lazarus, Docker) and provides one-click buttons to generate common, pre-configured tasks.
--   **Advanced Task Steps:** A rich library of specific, pre-built steps for different ecosystems, **now organized into logical categories in the UI for easy discovery**, simplifies creating complex workflows.
+-   **Project Intelligence:** Automatically detects project types (Node.js, Python, Go, Rust, Java/Maven, .NET, Delphi, Lazarus, Docker) and provides one-click buttons to generate common, pre-configured tasks.
+-   **Advanced Task Steps:** A rich library of specific, pre-built steps for different ecosystems—including Go, Rust, Java/Maven, and .NET—**now organized into logical categories in the UI for easy discovery**, simplifies creating complex workflows.
 -   **Task Environment Variables:** Define shell environment variables that are available to all command steps within a task.
 -   **Quick Actions:** Manually refresh repository state, copy URLs/paths with a single click, access all common actions via a right-click context menu, and reorder repositories with up/down buttons.
 -   **Powerful Command Palette:** Quickly access any action, task, or repository using the keyboard shortcut (`Ctrl/Cmd+K`) to open a powerful search-driven command modal.

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -32,7 +32,7 @@ The application uses a custom frameless window to achieve a modern, VSCode-like 
     -   Reads user settings on startup to configure features like the auto-updater's pre-release channel.
     -   Handles native OS interactions (dialogs, file system access).
     -   Listens for and responds to IPC (Inter-Process Communication) events. This includes:
-        -   **Project Intelligence:** Handles `get-project-info` and `get-project-suggestions` by analyzing the file system of a repository to detect technologies like Node.js, Python, Delphi, and Lazarus.
+        -   **Project Intelligence:** Handles `get-project-info` and `get-project-suggestions` by analyzing the file system of a repository to detect technologies like Node.js, Python, Go, Rust, Java/Maven, .NET, Delphi, and Lazarus.
         -   **Task Execution:** Executes shell commands for task steps. The `run-task-step` handler now contains logic to interpret and execute the new, ecosystem-specific step types (e.g., `PYTHON_INSTALL_DEPS`). It also handles setting environment variables for tasks.
         -   **Task Log Archiving:** Upon starting a task, it creates a timestamped log file in the user-configured directory. It then streams all `stdout` and `stderr` from the task's execution to this file, in addition to the live view in the UI.
         -   **VCS Commands:** Executes real Git/SVN commands for advanced features like checking status, fetching commit history (now for SVN as well), and managing branches.

--- a/types.ts
+++ b/types.ts
@@ -87,6 +87,25 @@ export enum TaskStepType {
   DELPHI_PACKAGE_INNO = 'DELPHI_PACKAGE_INNO',
   DELPHI_PACKAGE_NSIS = 'DELPHI_PACKAGE_NSIS',
   DELPHI_TEST_DUNITX = 'DELPHI_TEST_DUNITX',
+  // Go
+  GO_MOD_TIDY = 'GO_MOD_TIDY',
+  GO_FMT = 'GO_FMT',
+  GO_TEST = 'GO_TEST',
+  GO_BUILD = 'GO_BUILD',
+  // Rust
+  RUST_CARGO_FMT = 'RUST_CARGO_FMT',
+  RUST_CARGO_CLIPPY = 'RUST_CARGO_CLIPPY',
+  RUST_CARGO_CHECK = 'RUST_CARGO_CHECK',
+  RUST_CARGO_TEST = 'RUST_CARGO_TEST',
+  RUST_CARGO_BUILD = 'RUST_CARGO_BUILD',
+  // Java / Maven
+  MAVEN_CLEAN = 'MAVEN_CLEAN',
+  MAVEN_TEST = 'MAVEN_TEST',
+  MAVEN_PACKAGE = 'MAVEN_PACKAGE',
+  // .NET
+  DOTNET_RESTORE = 'DOTNET_RESTORE',
+  DOTNET_BUILD = 'DOTNET_BUILD',
+  DOTNET_TEST = 'DOTNET_TEST',
   // Python
   PYTHON_CREATE_VENV = 'PYTHON_CREATE_VENV',
   PYTHON_INSTALL_DEPS = 'PYTHON_INSTALL_DEPS',
@@ -418,12 +437,81 @@ export interface NodejsCapabilities {
   monorepo: { workspaces: boolean, turbo: boolean, nx: boolean, yarnBerryPnp: boolean };
 }
 
+export interface GoModuleInfo {
+  path: string;
+  module: string | null;
+  goVersion: string | null;
+  toolchain: string | null;
+}
+
+export interface GoCapabilities {
+  modules: GoModuleInfo[];
+  hasGoWork: boolean;
+  hasGoSum: boolean;
+  hasTests: boolean;
+}
+
+export interface RustPackageInfo {
+  path: string;
+  name: string | null;
+  edition: string | null;
+  rustVersion: string | null;
+  isWorkspace: boolean;
+}
+
+export interface RustCapabilities {
+  packages: RustPackageInfo[];
+  hasLockfile: boolean;
+  hasWorkspace: boolean;
+  workspaceMembers: string[];
+  hasTests: boolean;
+}
+
+export interface MavenProjectInfo {
+  path: string;
+  groupId: string | null;
+  artifactId: string | null;
+  packaging: string | null;
+  javaVersion: string | null;
+}
+
+export interface MavenCapabilities {
+  projects: MavenProjectInfo[];
+  hasWrapper: boolean;
+}
+
+export interface DotnetProjectInfo {
+  path: string;
+  targetFrameworks: string[];
+  outputType: string | null;
+  sdk: string | null;
+}
+
+export interface DotnetCapabilities {
+  projects: DotnetProjectInfo[];
+  hasSolution: boolean;
+}
+
+export interface ProjectInfoFiles {
+  dproj: string[];
+  goMod?: string[];
+  goWork?: string[];
+  cargoToml?: string[];
+  pomXml?: string[];
+  csproj?: string[];
+  sln?: string[];
+}
+
 export interface ProjectInfo {
   tags: string[];
-  files: { dproj: string[] };
+  files: ProjectInfoFiles;
   python?: PythonCapabilities;
   delphi?: DelphiCapabilities;
   nodejs?: NodejsCapabilities;
   lazarus?: LazarusCapabilities;
   docker?: DockerCapabilities;
+  go?: GoCapabilities;
+  rust?: RustCapabilities;
+  maven?: MavenCapabilities;
+  dotnet?: DotnetCapabilities;
 }


### PR DESCRIPTION
## Summary
- add Go, Rust, Maven, and .NET capability scanners in `getProjectInfo` and surface matching automation steps
- expose new task step enums, UI task generators, and availability filters for the new ecosystems
- update README and manuals to describe the expanded language support and default automations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e129eacf6083328380cbcce985da91