### PR TITLE
Prepare 0.27.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- **Workflow Template Explorer:** Added a CI tab to the repository form so you can browse `.github/workflows` files, fork recommended templates, edit YAML in place, run validation via `yamllint`/`act`, and push commits without leaving the modal.
+- _No changes yet._
+
+## [0.27.0]
+
+### Added
+- **Workflow Template Explorer:** Added a CI tab to the repository form so you can browse `.github/workflows` files, fork recommended templates, edit YAML in place, drag-resize the recommendations pane, run validation via `yamllint`/`act`, and push commits without leaving the modal. ([#111](https://github.com/beNative/git-automation/pull/111))
+
+### Changed
+- **Branch Toolbar Ergonomics:** Kept Git branch management controls on one row and routed selection/validation feedback through the shared status bar so warnings stay visible without overlapping toolbar buttons. ([#109](https://github.com/beNative/git-automation/pull/109))
+
+### Fixed
+- **Commit History Formatting:** Trimmed phantom whitespace and tightened list spacing in the commit history panel so entries align with their metadata. ([#110](https://github.com/beNative/git-automation/pull/110))
+- **Release Tab Layout:** Corrected flex sizing in the releases pane so the editor and list views share space predictably across window sizes. ([#108](https://github.com/beNative/git-automation/pull/108))
+- **Windows Manifest Hashing:** Recomputed hashes after the Windows artifact normalization step, added regression tests, and surfaced mismatches early to prevent update checksum errors. ([#107](https://github.com/beNative/git-automation/pull/107))
+- **Workflow Validation Wiring:** Bound the CI validator to the correct IPC sender so the Validate button reliably streams `yamllint`/`act` output back to the log panel. ([#111](https://github.com/beNative/git-automation/pull/111))
+
+### Documentation
+- Documented the workflow template explorer UI, validation workflow, branch toolbar refresh, and release layout polish delivered in version `0.27.0` across the README and manuals.
 
 ## [0.26.0]
 

--- a/FUNCTIONAL_MANUAL.md
+++ b/FUNCTIONAL_MANUAL.md
@@ -157,6 +157,15 @@ This tab provides a complete interface for managing your project's GitHub releas
 - **Toggle Pre-release:** Change a release from a stable to a pre-release and vice-versa.
 - **Delete Release:** Permanently delete a release from GitHub after a confirmation prompt.
 
+#### CI Tab (Git Only)
+Use the **CI** tab to manage GitHub Actions workflows without leaving the application.
+
+- **Workflow Browser:** The left rail lists every file inside `.github/workflows/`, including modified timestamps and a quick refresh button. Selecting a file loads it into the editor and surfaces its updated time plus an "Unsaved changes" indicator whenever edits diverge from disk.
+- **Template Forking:** A "Fork Template" footer lets you choose from curated templates (with recommended badges and descriptive tags), specify a destination filename, and create a workflow in place. Each template card can pre-fill the creation form so you can experiment quickly.
+- **Inline Editor:** The main panel exposes a monospace text area for editing YAML, a Save button, and validation controls. Save writes changes back to disk, while **Validate** shells out to `yamllint` (falling back to `act` when available) so syntax issues show up in the log stream before you commit.
+- **Commit & Push:** Provide a commit message and use **Commit & Push** to send edited workflows upstream. Buttons stay disabled while files are dirty or while operations run, mirroring the rest of the Repo Form ergonomics.
+- **Recommended Templates Pane:** The lower panel lists recommended templates with descriptions, tags, and quick actions to pre-populate the creation form. A draggable splitter lets you resize the pane to keep the editor comfortable on any display.
+
 After making any changes, click **"Save Repository"** on the main view to persist them.
 
 ## 4. The Task Log Panel
@@ -216,6 +225,6 @@ For advanced users, the settings view includes a **"JSON Config"** tab. This sec
 -   **Export Settings:** Click the "Export Settings" button to save your current configuration into a compressed `.zip` archive. This is useful for creating backups or sharing your setup.
 -   **Import Settings:** Click the "Import Settings" button. You can select a `.zip` archive (created via the export feature) or a raw `.json` file to restore a configuration. This will overwrite your current settings and restart the application.
 
-### Documentation Status for 0.26.0
+### Documentation Status for 0.27.0
 
-- Documented the Git branch maintenance toolbar, structured logging coverage for repository edits, and layout tightening delivered in version `0.26.0`.
+- Documented the CI workflow explorer, validation workflow, and the refreshed branch/release layouts introduced in version `0.27.0`.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This application provides a simple, powerful dashboard to manage and automate th
 -   **One-Click Update Check:** A "Check Updates" button fetches the latest information from all remotes, showing an "Updates Available" indicator on repositories that are behind.
 -   **Detailed VCS Status:** See ahead/behind status (Git) and a summary of file changes directly on the dashboard.
 -   **Branch Management:** Quickly switch branches from the dashboard. Git repositories can view, create, delete, and merge branches from the configuration view, prune stale remote references, and clean up merged local branches in one click, while SVN repositories can browse branches/trunk and switch working copies.
+-   **Workflow Template Explorer:** Edit CI pipelines directly inside the repository form with a dedicated tab that lists `.github/workflows` files, forks curated templates, lets you edit YAML side-by-side with recommendations, runs validation through `yamllint`/`act`, and pushes commits without leaving the modal.
 -   **Dirty Working Tree Safety:** Task runs are automatically paused when uncommitted changes are detected, giving you options to stash, force, or ignore selected files before continuing.
 -   **GitHub Release Management (Git):** See the latest release on the dashboard, and view, create, edit, and manage all your project's releases directly from the configuration view.
 -   **Commit History:** View the commit history for any Git or SVN repository, with **a stable, non-flickering UI**, search, and load-on-demand.
@@ -75,9 +76,9 @@ Follow this checklist when preparing a new minor or patch release:
     **Release Type** selector to the intended state (Full Release for GA builds, Draft or Pre-release as needed). Paste the freshly
     written changelog entry into the release body so the GitHub notes exactly match the repository history, then publish.
 
-### Documentation Status for 0.26.0
+### Documentation Status for 0.27.0
 
-- Documented the new Git branch maintenance actions, structured repository form logging, and UI layout refinements delivered in version `0.26.0`.
+- Documented the workflow template explorer, CI validation flow, and the branch/release layout refinements delivered in version `0.27.0`, confirming the README reflects the latest UI.
 
 ---
 _For developer information, including how to run this project in development mode or build it from source, please see the **Technical Manual** tab in the Info Hub._

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -36,6 +36,7 @@ The application uses a custom frameless window to achieve a modern, VSCode-like 
         -   **Task Execution:** Executes shell commands for task steps. The `run-task-step` handler now contains logic to interpret and execute the new, ecosystem-specific step types (e.g., `PYTHON_INSTALL_DEPS`). It also handles setting environment variables for tasks and tracks each spawned child process in the `runningProcesses` map so the `cancel-task` IPC requests from the renderer can terminate long-running work safely.
         -   **Task Log Archiving:** Upon starting a task, it creates a timestamped log file in the user-configured directory. It then streams all `stdout` and `stderr` from the task's execution to this file, in addition to the live view in the UI.
         -   **VCS Commands:** Executes real Git/SVN commands for advanced features like checking status, fetching commit history (now for SVN as well), and managing branches.
+        -   **Workflow Template Explorer:** Powers the CI tab by exposing IPC handlers such as `get-workflow-templates`, `list-workflow-files`, `read-workflow-file`, `write-workflow-file`, `create-workflow-from-template`, and `commit-workflow-files`, plus an event-driven `validate-workflow` runner that shells out to `yamllint` (or `act`) while streaming structured log output back to the renderer.
         -   **Executable Path Management:** Handles IPC calls for file pickers, auto-detection, and testing of user-configured executable paths.
         -   **External Links:** Handles requests from the renderer to open web links in the user-specified browser.
     -   **GitHub API:** Fetches release information for a repository using a user-provided Personal Access Token.
@@ -98,9 +99,9 @@ Use this process when shipping a new minor update or bugfix:
 6.  **Validate Update Metadata:** From the project root, execute `node electron/scripts/normalize-win32-artifacts.mjs` and confirm the `release/` directory contains `latest.yml` (x64), `latest-win32.yml` (ia32), and matching installer names. This verification prevents shipping a release without the updater manifests that GitHub users rely on.
 7.  **Publish on GitHub:** Draft a new release on GitHub, attach the installers from the `release/` folder, verify the tag/version details, and explicitly set the **Release Type** selector to match your intent (Full Release for GA builds or Draft/Pre-release when staging). Paste the current changelog entry into the notes so the GitHub release matches the repository history, then publish.
 
-### Documentation Status for 0.26.0
+### Documentation Status for 0.27.0
 
-- Documented the new branch maintenance IPC handlers, structured repository edit logging, and renderer layout refinements introduced in version `0.26.0`.
+- Documented the workflow template explorer IPC surface, renderer tooling, and CI validation path introduced in version `0.27.0`.
 ## 7. Automatic Updates
 
 The application is configured to automatically check for updates on startup using the `electron-updater` library.

--- a/docs/keyboard-shortcut-editor.md
+++ b/docs/keyboard-shortcut-editor.md
@@ -71,6 +71,6 @@ The catalog defines the canonical list of actions and their defaults.
 ## Future Hooks
 - The structure supports hooking into a runtime shortcut registry (e.g., via a dedicated context) by indexing `settings.keyboardShortcuts.bindings`. Any consumer can reuse `shortcutKey` and the catalog to register listeners or show active shortcut hints. The state object is already versioned (`version: 1`) to accommodate future schema migrations.【F:keyboardShortcuts.ts†L285-L313】【F:types.ts†L23-L49】
 
-## Documentation Status for 0.26.0
-- Re-validated that the shortcut editor architecture, UI flows, and persistence notes above still reflect the current implementation for version `0.26.0`. The 0.26.0 branch maintenance and logging updates do not affect the shortcut editor, so no changes were required beyond recording this confirmation for the release audit trail.
+## Documentation Status for 0.27.0
+- Re-reviewed the shortcut editor architecture for version `0.27.0` and confirmed the CI workflow additions do not impact these flows, so the specification remains accurate aside from recording this verification for the audit trail.
 

--- a/docs/releases/0.27.0.md
+++ b/docs/releases/0.27.0.md
@@ -1,0 +1,36 @@
+# Git Automation Dashboard 0.27.0 Release Notes
+
+## Summary
+Git Automation Dashboard 0.27.0 introduces a full Workflow Template Explorer so you can curate, edit, validate, and ship GitHub Actions pipelines without leaving the Repo Form. Supporting updates polish the branch toolbar, tighten commit history formatting, stabilize the releases tab layout, and harden the Windows packaging workflow by validating manifest hashes after normalization.
+
+## What's Changed
+
+### Workflow Template Explorer (#111)
+- Added a dedicated **CI** tab that lists every `.github/workflows` file, surfaces timestamps, and keeps unsaved state visible while you edit YAML inline.
+- Surfaced curated template recommendations (with tags and badges) alongside a drag-resizable pane so you can fork a starting point, rename it, and create new workflow files in one flow.
+- Connected Save, Validate, and Commit & Push actions to the Electron bridge so you can persist edits, run `yamllint`/`act` validation, and publish commits without leaving the modal.
+
+### Branch & History UX (#109, #110)
+- Rebalanced the Git branch toolbar so destructive actions stay on one row while routing feedback through the shared status bar, keeping warnings legible even on narrow windows.
+- Cleaned up commit history formatting by trimming phantom whitespace and aligning metadata, improving readability for long commit lists.
+
+### Release & Packaging Reliability (#108, #107)
+- Fixed the releases tab layout so the list and editor sections share the viewport predictably, preventing scroll traps while editing notes.
+- Taught the Windows artifact normalization script to recompute SHA512 hashes after renaming installers, added regression tests, and stopped publishing builds when manifest entries drift.
+
+### Validation Fixes (#111)
+- Bound the CI validator to the correct IPC sender so the Validate button reliably streams `yamllint`/`act` output back to the log console.
+
+## Breaking Changes
+- None. This release is backwards compatible.
+
+## Upgrade Notes
+1. Install `yamllint` or `act` locally to take advantage of the CI tab's validation workflow before committing edited YAML.
+2. Continue running `node electron/scripts/normalize-win32-artifacts.mjs` after `npm run pack`; the script now enforces manifest hash parity and will fail fast when mismatches occur.
+
+## Acknowledgements
+- Pull Request [#107](https://github.com/beNative/git-automation/pull/107) – Fix automatic update checksum mismatch.
+- Pull Request [#108](https://github.com/beNative/git-automation/pull/108) – Fix release pane resizing issue.
+- Pull Request [#109](https://github.com/beNative/git-automation/pull/109) – Move buttons in branches tab layout.
+- Pull Request [#110](https://github.com/beNative/git-automation/pull/110) – Fix commit message formatting.
+- Pull Request [#111](https://github.com/beNative/git-automation/pull/111) – Add CI tab for workflow template editing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "git-automation-dashboard",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "git-automation-dashboard",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "MIT",
       "dependencies": {
         "@google/genai": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-automation-dashboard",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "A dashboard to manage and automate the workflow for a set of Git repositories.",
   "main": "dist/main.js",
   "author": "Tim Sinaeve <tim.sinaeve@gmail.com>",


### PR DESCRIPTION
## Summary
- add documentation for the new workflow template explorer and branch/release polish
- record the 0.27.0 release in the changelog and docs/releases along with a README feature update
- bump the package version to 0.27.0 for publishing

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919fa42f3cc8332a748fe701475e4e2)